### PR TITLE
fix creation/deletion race in mqueue::Dispatcher

### DIFF
--- a/rtt/transports/mqueue/Dispatcher.cpp
+++ b/rtt/transports/mqueue/Dispatcher.cpp
@@ -40,7 +40,8 @@
 
 namespace RTT {
     namespace mqueue {
-        Dispatcher* Dispatcher::DispatchI = 0;
+        Dispatcher::shared_ptr Dispatcher::DispatchI = 0;
+        os::Mutex Dispatcher::DispatchILock;
 
         void intrusive_ptr_add_ref(const RTT::mqueue::Dispatcher* p ) {
             p->refcount.inc();

--- a/rtt/transports/mqueue/Dispatcher.hpp
+++ b/rtt/transports/mqueue/Dispatcher.hpp
@@ -61,10 +61,15 @@ namespace RTT {
          */
         class Dispatcher : public Activity
         {
+            typedef boost::intrusive_ptr<Dispatcher> shared_ptr;
+        public:
+
             friend void intrusive_ptr_add_ref(const RTT::mqueue::Dispatcher* p );
             friend void intrusive_ptr_release(const RTT::mqueue::Dispatcher* p );
             mutable os::AtomicInt refcount;
-            static Dispatcher* DispatchI;
+
+            static os::Mutex DispatchILock;
+            static shared_ptr DispatchI;
 
             typedef std::map<mqd_t,base::ChannelElementBase*> MQMap;
             MQMap mqmap;
@@ -129,10 +134,9 @@ namespace RTT {
             }
 
         public:
-            typedef boost::intrusive_ptr<Dispatcher> shared_ptr;
-
             static Dispatcher::shared_ptr Instance() {
-                if ( DispatchI == 0) {
+                os::MutexLock lock(DispatchILock);
+                if (!DispatchI) {
                     DispatchI = new Dispatcher("MQueueDispatch");
                     DispatchI->start();
                 }


### PR DESCRIPTION
The class was obviously assuming that intrusive_ptr would be thread
safe, which we know is not true on deletion/creation races. It would
lead to crashes in cases where the last connection would be closed
at the same time than a new connections would appear.

The fix I've decided to pick is to simply keep the dispatcher alive.
It is a single thread, unique per RTT process. I am essentially assuming
that if someone tries to create MQ connections, he/she will try again
and that deleting the dispatcher thread provides very little.

In my case, it started appearing on a system where the MQ was not well
configured (low number of MQueues available). In this
configuration, Syskit would attempt to create an MQ, it would fail and
then would fallback to CORBA. Since Syskit parallelizes connection
creation, the situation that would trigger this bug appeared often enough