### PR TITLE
Fix transition to exception

### DIFF
--- a/rtt/base/TaskCore.cpp
+++ b/rtt/base/TaskCore.cpp
@@ -157,7 +157,7 @@ namespace RTT {
     void TaskCore::exception() {
         //log(Error) <<"Exception happend in TaskCore."<<endlog();
         TaskState copy = mTaskState;
-        mTargetState = mTaskState = Exception;
+        mTargetState = Exception;
         TRY (
             if ( copy >= Running ) {
                 stopHook();
@@ -166,6 +166,7 @@ namespace RTT {
                 cleanupHook();
             }
             exceptionHook();
+            mTaskState = Exception;
         ) CATCH(std::exception const& e,
             log(RTT::Error) << "stopHook(), cleanupHook() and/or exceptionHook() raised " << e.what() << ", going into Fatal" << endlog();
             fatal();

--- a/tests/datasource_test.cpp
+++ b/tests/datasource_test.cpp
@@ -178,7 +178,9 @@ BOOST_AUTO_TEST_CASE( testArrayPartDataSource )
     index->set( 3 );
     d->set( 'L' );
     BOOST_CHECK_EQUAL( "WorLd", btype.c );
-    BOOST_CHECK( strcmp( &d->set(), &abase->get().c[3]) == 0 );
+
+    BType b = abase->get();
+    BOOST_CHECK( strcmp( &d->set(), &b.c[3]) == 0 );
     BOOST_CHECK_EQUAL( &d->set(), &btype.c[3] );
 }
 

--- a/tests/taskstates_test.cpp
+++ b/tests/taskstates_test.cpp
@@ -53,9 +53,9 @@ public:
         validstart = true;
         do_error = false;
         do_fatal = false;
-        do_throw=false;
-        do_throw2=false;
-        do_throw3=false;
+        do_throw_in_updateHook=false;
+        do_throw_in_errorHook=false;
+        do_throw_in_exceptionHook=false;
         do_trigger=false;
         do_breakUH=false;
         do_block=false;
@@ -117,7 +117,7 @@ public:
             BOOST_CHECK( getTargetState() == Exception );
         }
         didexcept = true;
-        if (do_throw3)
+        if (do_throw_in_exceptionHook)
             throw A();
     }
 
@@ -132,7 +132,7 @@ public:
             this->fatal();
         if (do_error)
             this->error();
-        if (do_throw)
+        if (do_throw_in_updateHook)
             throw A();
         if (do_trigger) {
             this->trigger();
@@ -157,7 +157,7 @@ public:
         diderror = true;
         if (do_fatal)
             this->fatal();
-        if (do_throw2)
+        if (do_throw_in_errorHook)
             throw A();
     }
 
@@ -166,7 +166,7 @@ public:
     bool didstop;
     bool didcleanup;
     bool didupdate,diderror,didexcept, didbreakUH;
-    bool do_fatal, do_error, do_throw,do_throw2,do_throw3, do_trigger, do_breakUH, do_block, do_checks, do_stop;
+    bool do_fatal, do_error, do_throw_in_updateHook,do_throw_in_errorHook,do_throw_in_exceptionHook, do_trigger, do_breakUH, do_block, do_checks, do_stop;
     int  updatecount;
 };
 
@@ -569,7 +569,7 @@ BOOST_AUTO_TEST_CASE( testFailingTCStates)
     BOOST_CHECK( stc->didupdate == true );
 
     // Error state by throwing in updateHook()
-    stc->do_throw = true;
+    stc->do_throw_in_updateHook = true;
     // Running state / updateHook :
     SimulationThread::Instance()->run(1);
     BOOST_CHECK( stc->inRunTimeError() == false );
@@ -577,7 +577,7 @@ BOOST_AUTO_TEST_CASE( testFailingTCStates)
     BOOST_CHECK( stc->didexcept == true );
     BOOST_CHECK( stc->isActive() == true );  // still active
     stc->resetFlags();
-    stc->do_throw = false;
+    stc->do_throw_in_updateHook = false;
     stc->recover();
     SimulationThread::Instance()->run(1);
     BOOST_CHECK( stc->isConfigured() == false );
@@ -589,8 +589,8 @@ BOOST_AUTO_TEST_CASE( testFailingTCStates)
 
     // Fatal Error state by throwing in exceptionHook()
     stc->do_error = false;
-    stc->do_throw = true;
-    stc->do_throw3 = true;
+    stc->do_throw_in_updateHook = true;
+    stc->do_throw_in_exceptionHook = true;
     // Running state / updateHook :
     SimulationThread::Instance()->run(1);
     BOOST_CHECK( stc->inRunTimeError() == false );

--- a/tests/taskthread_fd_test.cpp
+++ b/tests/taskthread_fd_test.cpp
@@ -30,8 +30,11 @@
 using namespace std;
 
 #include <boost/test/unit_test.hpp>
+#if BOOST_VERSION >= 105900
+#include <boost/test/tools/floating_point_comparison.hpp>
+#else
 #include <boost/test/floating_point_comparison.hpp>
-
+#endif
 
 using namespace RTT;
 

--- a/tests/unit.hpp
+++ b/tests/unit.hpp
@@ -36,7 +36,12 @@
 #include <boost/test/unit_test_suite.hpp>
 #endif
 #include <boost/test/unit_test.hpp>
+
+#if BOOST_VERSION >= 105900
+#include <boost/test/tools/floating_point_comparison.hpp>
+#else
 #include <boost/test/floating_point_comparison.hpp>
+#endif
 
 using namespace RTT;
 using namespace RTT::detail;


### PR DESCRIPTION
exception() was setting both TargetState and State to Exception
on entering. This meant that an external observer had no chance
to synchronize on the actual end of transition (i.e. Exception
would be returned by getState() while the component could be
still running).

This could cause synchronization issues if e.g. the external observer
was trying to recover() and configure(). In this case, the RTT runtime
would happily let it recover and also configure, **concurrently to having
the stopHook/cleanupHook/exceptionHook called by exception()** since
configure() does not synchronize with the component's thread.