### PR TITLE
chore: Increase corba dispather queue size

### DIFF
--- a/rtt/transports/corba/CorbaDispatcher.hpp
+++ b/rtt/transports/corba/CorbaDispatcher.hpp
@@ -71,13 +71,13 @@ namespace RTT {
 
             CorbaDispatcher( const std::string& name)
             : Activity(defaultScheduler, defaultPriority, 0.0, 0, name),
-              RClist(20,2),
+              RClist(40,2),
               do_exit(false)
               {}
 
             CorbaDispatcher( const std::string& name, int scheduler, int priority)
             : Activity(scheduler, priority, 0.0, 0, name),
-              RClist(20,2),
+              RClist(40,2),
               do_exit(false)
               {}
 


### PR DESCRIPTION
Doubling the queue size because it got small in some use cases