### PR TITLE
Cleanup: CorbaDispatcher: Remove find retry, unsafe initialisation of mlock

### DIFF
--- a/rtt/transports/corba/CorbaDispatcher.cpp
+++ b/rtt/transports/corba/CorbaDispatcher.cpp
@@ -41,7 +41,7 @@
 namespace RTT {
     using namespace corba;
     CorbaDispatcher::DispatchMap CorbaDispatcher::DispatchI;
-    os::Mutex* CorbaDispatcher::mlock = 0;
+    os::Mutex CorbaDispatcher::mlock;
 
     int CorbaDispatcher::defaultScheduler = ORO_SCHED_RT;
     int CorbaDispatcher::defaultPriority  = os::LowestPriority;


### PR DESCRIPTION
Concurrent use of ::Instance when mlock is not initialized would create two instances of the os::Mutex, which could then potentially both be used, since the compiler does not have to expect mlock to change and may cache its current value.

Creating an os::Mutex in global scope during library init is already used in rtt/transports/mqueue/Dispatcher.hpp.