### PR TITLE
feat: allow disabling the signalling remote call in pull corba connections

### DIFF
--- a/rtt/ConnPolicy.cpp
+++ b/rtt/ConnPolicy.cpp
@@ -81,7 +81,10 @@ namespace RTT
     }
 
     ConnPolicy::ConnPolicy(int type /* = DATA*/, int lock_policy /*= LOCK_FREE*/)
-        : type(type), init(false), lock_policy(lock_policy), pull(false), size(0), transport(0), data_size(0) {}
+        : type(type), init(false), lock_policy(lock_policy), pull(false), size(0)
+        , transport(0)
+        , signalling(true)
+        , data_size(0) {}
 
     /** @cond */
     /** This is dead code. We use the boost::serialization now.

--- a/rtt/ConnPolicy.hpp
+++ b/rtt/ConnPolicy.hpp
@@ -158,8 +158,10 @@ namespace RTT {
         /** This is the locking policy on the connection */
         int    lock_policy;
         /** If true, then the sink will have to pull data. Otherwise, it is pushed
-         * from the source. In both cases, the reader side is notified that new
-         * data is available by base::ChannelElementBase::signal()
+         * from the source. 
+         *
+         * When in `pull`, `signalling` determines whether or not the element
+         * will explicitly forward a signal to the remote side
          */
         bool   pull;
         /** If the connection is a buffered connection, the size of the buffer */
@@ -169,6 +171,11 @@ namespace RTT {
          * is used for inter-process or networked communication transports.
          */
         int    transport;
+        /**
+         * Whether `pull` connection will explicitly send a signal to the remote
+         * when a new sample is received. `true` is the default.
+         */
+        bool   signalling;
 
         /**
          * Suggest the payload size of the data sent over this channel. Connections

--- a/rtt/transports/corba/CorbaConnPolicy.cpp
+++ b/rtt/transports/corba/CorbaConnPolicy.cpp
@@ -52,6 +52,7 @@ RTT::corba::CConnPolicy toCORBA(RTT::ConnPolicy const& policy)
     corba_policy.init        = policy.init;
     corba_policy.lock_policy = RTT::corba::CLockPolicy(policy.lock_policy);
     corba_policy.pull        = policy.pull;
+    corba_policy.signalling  = policy.signalling;
     corba_policy.size        = policy.size;
     corba_policy.data_size   = policy.data_size;
     corba_policy.transport   = policy.transport;
@@ -66,6 +67,7 @@ RTT::ConnPolicy toRTT(RTT::corba::CConnPolicy const& corba_policy)
     policy.init        = corba_policy.init;
     policy.lock_policy = corba_policy.lock_policy;
     policy.pull        = corba_policy.pull;
+    policy.signalling  = corba_policy.signalling;
     policy.size        = corba_policy.size;
     policy.data_size   = corba_policy.data_size;
     policy.transport   = corba_policy.transport;

--- a/rtt/transports/corba/CorbaLib.cpp
+++ b/rtt/transports/corba/CorbaLib.cpp
@@ -115,7 +115,7 @@ namespace RTT {
 
             virtual base::ChannelElementBase* buildDataStorage(ConnPolicy const& policy) const { return 0; }
 
-            virtual CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface*, ::PortableServer::POA* poa, bool) const {
+            virtual CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface*, ::PortableServer::POA* poa, bool, bool) const {
                 Logger::In in("CorbaFallBackProtocol");
                 log(Error) << "Could create Channel : data type not known to CORBA Transport." <<Logger::endl;
                 return 0;

--- a/rtt/transports/corba/CorbaTemplateProtocol.hpp
+++ b/rtt/transports/corba/CorbaTemplateProtocol.hpp
@@ -69,8 +69,8 @@ namespace RTT
            */
           typedef typename Property<T>::DataSourceType PropertyType;
 
-          CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface* sender,PortableServer::POA_ptr poa, bool is_pull) const
-          { return new RemoteChannelElement<T>(*this, sender, poa, is_pull); }
+          CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface* sender,PortableServer::POA_ptr poa, bool is_pull, bool is_signalling) const
+          { return new RemoteChannelElement<T>(*this, sender, poa, is_pull, is_signalling); }
 
           /**
            * Create an transportable object for a \a protocol which contains the value of \a source.

--- a/rtt/transports/corba/CorbaTypeTransporter.hpp
+++ b/rtt/transports/corba/CorbaTypeTransporter.hpp
@@ -83,7 +83,7 @@ namespace RTT {
 	     * @param poa The POA to manage the server code.
 	     * @return the created CChannelElement_i.
 	     */
-	    virtual CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface* sender, ::PortableServer::POA* poa, bool is_pull) const = 0;
+	    virtual CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface* sender, ::PortableServer::POA* poa, bool is_pull, bool is_signalling) const = 0;
 
 	    /**
 	     * The CORBA transport does not support creating 'CORBA' streams.

--- a/rtt/transports/corba/DataFlow.idl
+++ b/rtt/transports/corba/DataFlow.idl
@@ -19,6 +19,7 @@ module RTT
         boolean init;
         CLockPolicy lock_policy;
         boolean pull;
+        boolean signalling;
         long size;
         long transport;
         long data_size;

--- a/rtt/transports/corba/DataFlowI.cpp
+++ b/rtt/transports/corba/DataFlowI.cpp
@@ -392,7 +392,7 @@ CChannelElement_ptr CDataFlowInterface_i::buildChannelOutput(
 
     ChannelElementBase::shared_ptr end = type_info->buildChannelOutput(*port);
     CRemoteChannelElement_i* this_element =
-        transporter->createChannelElement_i(mdf, mpoa, corba_policy.pull);
+        transporter->createChannelElement_i(mdf, mpoa, corba_policy.pull, corba_policy.signalling);
     this_element->setCDataFlowInterface(this);
 
     /*
@@ -479,7 +479,7 @@ CChannelElement_ptr CDataFlowInterface_i::buildChannelInput(
 
     // The channel element that exposes our channel in CORBA
     CRemoteChannelElement_i* this_element;
-    PortableServer::ServantBase_var servant = this_element = transporter->createChannelElement_i(mdf, mpoa, corba_policy.pull);
+    PortableServer::ServantBase_var servant = this_element = transporter->createChannelElement_i(mdf, mpoa, corba_policy.pull, corba_policy.signalling);
     this_element->setCDataFlowInterface(this);
 
     // Attach the corba channel element first (so OOB is after corba).

--- a/rtt/transports/corba/RemotePorts.cpp
+++ b/rtt/transports/corba/RemotePorts.cpp
@@ -144,7 +144,7 @@ RTT::base::ChannelElementBase::shared_ptr RemoteInputPort::buildRemoteChannelOut
     // and connect it to the remote side and vice versa.
     CRemoteChannelElement_i*  local =
         static_cast<CorbaTypeTransporter*>(type->getProtocol(ORO_CORBA_PROTOCOL_ID))
-                            ->createChannelElement_i(output_port.getInterface(), mpoa, policy.pull);
+                            ->createChannelElement_i(output_port.getInterface(), mpoa, policy.pull, policy.signalling);
 
     CRemoteChannelElement_var proxy = local->_this();
     local->setRemoteSide(remote);


### PR DESCRIPTION
When the connection is bad or simply breaks, the signalling call can block, even though it is defined oneway - the TCP connection still needs to go through. This actually blocks any other connection that is on the same corba dispatcher, with catastrophic results.

Since orocos.rb/async and vizkit do not use the functionality, provide the possibility to disable signalling altogether.