### PR TITLE
feat: give control on which CORBA connections are served by which dispatchers

### DIFF
--- a/rtt/transports/corba/CorbaDispatcher.cpp
+++ b/rtt/transports/corba/CorbaDispatcher.cpp
@@ -142,6 +142,12 @@ void CorbaDispatcher::Deref(std::string const& name) {
         DispatchI.erase(result);
     }
 
+    if (!dispatcher) {
+        return;
+    }
+
+    dispatcher->stop();
+    dispatcher->terminate();
     delete dispatcher;
 }
 

--- a/rtt/transports/corba/CorbaDispatcher.cpp
+++ b/rtt/transports/corba/CorbaDispatcher.cpp
@@ -37,12 +37,130 @@
 
 
 #include "CorbaDispatcher.hpp"
+#include <boost/lexical_cast.hpp>
 
-namespace RTT {
-    using namespace corba;
-    CorbaDispatcher::DispatchMap CorbaDispatcher::DispatchI;
-    os::Mutex CorbaDispatcher::mlock;
+using namespace RTT;
+using namespace RTT::corba;
 
-    int CorbaDispatcher::defaultScheduler = ORO_SCHED_RT;
-    int CorbaDispatcher::defaultPriority  = os::LowestPriority;
+CorbaDispatcher::DispatchMap CorbaDispatcher::DispatchI;
+os::Mutex CorbaDispatcher::mlock;
+
+int CorbaDispatcher::defaultScheduler = ORO_SCHED_RT;
+int CorbaDispatcher::defaultPriority  = os::LowestPriority;
+
+CorbaDispatcher::DispatchEntry& CorbaDispatcher::Get(std::string const& name, int scheduler, int priority)
+{
+    DispatchMap::iterator result = DispatchI.find(name);
+    if ( result != DispatchI.end() )
+        return result->second;
+
+    CorbaDispatcher* dispatcher = new CorbaDispatcher( name, scheduler, priority );
+    dispatcher->start();
+    return (DispatchI[name] = DispatchEntry(dispatcher));
+}
+
+CorbaDispatcher* CorbaDispatcher::Instance(DataFlowInterface* iface, int scheduler, int priority) {
+    return Instance(defaultDispatcherName(iface), scheduler, priority);
+}
+
+std::string CorbaDispatcher::defaultDispatcherName(DataFlowInterface* iface)
+{
+    std::string name;
+    if ( iface == 0 || iface->getOwner() == 0)
+        name = "Global";
+    else
+        name = iface->getOwner()->getName();
+    return name + ".CorbaDispatch." + boost::lexical_cast<std::string>(reinterpret_cast<uint64_t>(iface));
+}
+
+/**
+ * Create a new dispatcher and registers it under a certain name
+ *
+ * @param name the dispatcher registration name
+ * @return
+ */
+CorbaDispatcher* CorbaDispatcher::Instance(std::string const& name, int scheduler, int priority) {
+    os::MutexLock lock(mlock);
+
+    return Get(name, scheduler, priority).dispatcher;
+}
+
+
+CorbaDispatcher* CorbaDispatcher::Acquire(RTT::DataFlowInterface* interface, int scheduler, int priority) {
+    return Acquire(defaultDispatcherName(interface), scheduler, priority);
+}
+
+CorbaDispatcher* CorbaDispatcher::Acquire(std::string const& name, int scheduler, int priority) {
+    os::MutexLock lock(mlock);
+
+    DispatchEntry& entry = Get(name, scheduler, priority);
+    entry.refcount.inc();
+    return entry.dispatcher;
+}
+
+void CorbaDispatcher::Release(CorbaDispatcher* dispatcher) {
+    return Release(dispatcher->getName());
+}
+
+void CorbaDispatcher::Release(std::string const& name) {
+    CorbaDispatcher* dispatcher = nullptr;
+
+    {
+        os::MutexLock lock(mlock);
+
+        DispatchMap::iterator result = DispatchI.find(name);
+        if (result == DispatchI.end()) {
+            return;
+        }
+
+        if (!result->second.refcount.dec_and_test()) {
+            return;
+        }
+
+        dispatcher = result->second.dispatcher;
+        DispatchI.erase(result);
+    }
+
+    delete dispatcher;
+}
+
+static void hasElement(base::ChannelElementBase::shared_ptr c0, base::ChannelElementBase::shared_ptr c1, bool& result)
+{
+    result = result || (c0 == c1);
+}
+
+void CorbaDispatcher::dispatchChannel( base::ChannelElementBase::shared_ptr chan ) {
+    bool has_element = false;
+    RClist.apply(boost::bind(&hasElement, _1, chan, boost::ref(has_element)));
+    if (!has_element) {
+        while (!RClist.append( chan )) {
+            RClist.grow(20);
+        }
+    }
+    this->trigger();
+}
+
+void CorbaDispatcher::cancelChannel( base::ChannelElementBase::shared_ptr chan ) {
+    RClist.erase( chan );
+}
+
+bool CorbaDispatcher::initialize() {
+    log(Info) <<"Started " << this->getName() << "." <<endlog();
+    do_exit = false;
+    return true;
+}
+
+void CorbaDispatcher::loop() {
+    while ( !RClist.empty() && !do_exit) {
+        base::ChannelElementBase::shared_ptr chan = RClist.front();
+        CRemoteChannelElement_i* rbase = dynamic_cast<CRemoteChannelElement_i*>(chan.get());
+        if (rbase)
+            rbase->transferSamples();
+        RClist.erase( chan );
+    }
+}
+
+bool CorbaDispatcher::breakLoop() {
+    do_exit = true;
+    return true;
 }

--- a/rtt/transports/corba/CorbaLib.cpp
+++ b/rtt/transports/corba/CorbaLib.cpp
@@ -115,7 +115,13 @@ namespace RTT {
 
             virtual base::ChannelElementBase* buildDataStorage(ConnPolicy const& policy) const { return 0; }
 
-            virtual CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface*, ::PortableServer::POA* poa, bool, bool) const {
+            virtual CRemoteChannelElement_i* createOutputChannelElement_i(std::string const&, ::PortableServer::POA* poa, bool, bool) const {
+                Logger::In in("CorbaFallBackProtocol");
+                log(Error) << "Could create Channel : data type not known to CORBA Transport." <<Logger::endl;
+                return 0;
+
+            }
+            virtual CRemoteChannelElement_i* createInputChannelElement_i(::PortableServer::POA* poa, bool) const {
                 Logger::In in("CorbaFallBackProtocol");
                 log(Error) << "Could create Channel : data type not known to CORBA Transport." <<Logger::endl;
                 return 0;

--- a/rtt/transports/corba/CorbaTemplateProtocol.hpp
+++ b/rtt/transports/corba/CorbaTemplateProtocol.hpp
@@ -69,8 +69,11 @@ namespace RTT
            */
           typedef typename Property<T>::DataSourceType PropertyType;
 
-          CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface* sender,PortableServer::POA_ptr poa, bool is_pull, bool is_signalling) const
-          { return new RemoteChannelElement<T>(*this, sender, poa, is_pull, is_signalling); }
+          CRemoteChannelElement_i* createOutputChannelElement_i(std::string const& dispatcherName,PortableServer::POA_ptr poa, bool is_pull, bool is_signalling) const
+          { return new RemoteChannelElement<T>(dispatcherName, *this, poa, is_pull, is_signalling); }
+
+          CRemoteChannelElement_i* createInputChannelElement_i(PortableServer::POA_ptr poa, bool is_pull) const
+          { return new RemoteChannelElement<T>(*this, poa, is_pull); }
 
           /**
            * Create an transportable object for a \a protocol which contains the value of \a source.

--- a/rtt/transports/corba/CorbaTypeTransporter.hpp
+++ b/rtt/transports/corba/CorbaTypeTransporter.hpp
@@ -83,7 +83,15 @@ namespace RTT {
 	     * @param poa The POA to manage the server code.
 	     * @return the created CChannelElement_i.
 	     */
-	    virtual CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface* sender, ::PortableServer::POA* poa, bool is_pull, bool is_signalling) const = 0;
+	    virtual CRemoteChannelElement_i* createOutputChannelElement_i(std::string const& dispatcherName, ::PortableServer::POA* poa, bool is_pull, bool is_signalling) const = 0;
+
+	    /**
+	     * Builds a channel element for remote transport in both directions.
+	     * @param sender The data flow interface which will be sending or receiving this channel.
+	     * @param poa The POA to manage the server code.
+	     * @return the created CChannelElement_i.
+	     */
+	    virtual CRemoteChannelElement_i* createInputChannelElement_i(::PortableServer::POA* poa, bool is_pull) const = 0;
 
 	    /**
 	     * The CORBA transport does not support creating 'CORBA' streams.

--- a/rtt/transports/corba/DataFlowI.cpp
+++ b/rtt/transports/corba/DataFlowI.cpp
@@ -398,11 +398,10 @@ CChannelElement_ptr CDataFlowInterface_i::buildChannelOutput(
 
     CORBA_CHECK_THREAD();
     ConnPolicy policy = toRTT(corba_policy);
-    std::string dispatcherName = dispatcherNameFromPolicy(mdf, policy);
 
     ChannelElementBase::shared_ptr end = type_info->buildChannelOutput(*port);
     CRemoteChannelElement_i* this_element =
-        transporter->createOutputChannelElement_i(dispatcherName, mpoa, corba_policy.pull, corba_policy.signalling);
+        transporter->createInputChannelElement_i(mpoa, corba_policy.pull);
     this_element->setCDataFlowInterface(this);
 
     /*
@@ -487,9 +486,10 @@ CChannelElement_ptr CDataFlowInterface_i::buildChannelInput(
     // Now create the output-side channel elements.
     ChannelElementBase::shared_ptr start = type_info->buildChannelInput(*port);
 
+    std::string dispatcherName = dispatcherNameFromPolicy(mdf, policy);
     // The channel element that exposes our channel in CORBA
     CRemoteChannelElement_i* this_element =
-        transporter->createInputChannelElement_i(mpoa, corba_policy.pull);
+        transporter->createOutputChannelElement_i(dispatcherName, mpoa, corba_policy.pull, corba_policy.signalling);
     PortableServer::ServantBase_var servant = this_element;
     this_element->setCDataFlowInterface(this);
 

--- a/rtt/transports/corba/DataFlowI.cpp
+++ b/rtt/transports/corba/DataFlowI.cpp
@@ -54,6 +54,7 @@
 #include "RemotePorts.hpp"
 #include "RemoteConnID.hpp"
 #include <rtt/os/MutexLock.hpp>
+#include "CorbaDispatcher.hpp"
 
 #include <iostream>
 
@@ -364,6 +365,15 @@ void CDataFlowInterface_i::removeStream( const char* port, const char* stream_na
     p->removeConnection( &rcid );
 }
 
+std::string CDataFlowInterface_i::dispatcherNameFromPolicy(RTT::DataFlowInterface* interface, RTT::ConnPolicy const& policy)
+{
+    if ( policy.transport !=0 && policy.transport != ORO_CORBA_PROTOCOL_ID)
+        return CorbaDispatcher::defaultDispatcherName(interface);
+    else if (policy.name_id.empty())
+        return CorbaDispatcher::defaultDispatcherName(interface);
+    else
+        return policy.name_id;
+}
 
 CChannelElement_ptr CDataFlowInterface_i::buildChannelOutput(
         const char* port_name, CConnPolicy & corba_policy) ACE_THROW_SPEC ((
@@ -387,12 +397,12 @@ CChannelElement_ptr CDataFlowInterface_i::buildChannelOutput(
         throw CNoCorbaTransport();
 
     CORBA_CHECK_THREAD();
-    // Convert to RTT policy.
-    ConnPolicy policy2 = toRTT(corba_policy);
+    ConnPolicy policy = toRTT(corba_policy);
+    std::string dispatcherName = dispatcherNameFromPolicy(mdf, policy);
 
     ChannelElementBase::shared_ptr end = type_info->buildChannelOutput(*port);
     CRemoteChannelElement_i* this_element =
-        transporter->createChannelElement_i(mdf, mpoa, corba_policy.pull, corba_policy.signalling);
+        transporter->createOutputChannelElement_i(dispatcherName, mpoa, corba_policy.pull, corba_policy.signalling);
     this_element->setCDataFlowInterface(this);
 
     /*
@@ -406,10 +416,10 @@ CChannelElement_ptr CDataFlowInterface_i::buildChannelOutput(
             log(Error) << "No such transport registered. Check your corba_policy.transport settings or add the transport for type "<< type_info->getTypeName() <<endlog();
             return RTT::corba::CChannelElement::_nil();
         }
-        RTT::base::ChannelElementBase::shared_ptr ceb = type_info->getProtocol(corba_policy.transport)->createStream(port, policy2, false);
+        RTT::base::ChannelElementBase::shared_ptr ceb = type_info->getProtocol(corba_policy.transport)->createStream(port, policy, false);
         // if no user supplied name, pass on the new name.
         if ( strlen( corba_policy.name_id.in()) == 0 )
-            corba_policy.name_id = CORBA::string_dup( policy2.name_id.c_str() );
+            corba_policy.name_id = CORBA::string_dup( policy.name_id.c_str() );
 
         if (ceb) {
             // override, insert oob element between corba and endpoint and add a buffer between oob and endpoint.
@@ -417,7 +427,7 @@ CChannelElement_ptr CDataFlowInterface_i::buildChannelOutput(
             ChannelElementBase::shared_ptr buf = type_info->buildDataStorage(toRTT(corba_policy));
             ceb->setOutput( buf );
             buf->setOutput(end);
-            log(Info) <<"Receiving data for port "<< policy2.name_id << " from out-of-band protocol "<< corba_policy.transport <<endlog();
+            log(Info) <<"Receiving data for port "<< policy.name_id << " from out-of-band protocol "<< corba_policy.transport <<endlog();
         } else {
             log(Error) << "The type transporter for type "<<type_info->getTypeName()<< " failed to create an out-of-band endpoint for port " << port_name<<endlog();
             return RTT::corba::CChannelElement::_nil();
@@ -472,14 +482,15 @@ CChannelElement_ptr CDataFlowInterface_i::buildChannelInput(
 
     CORBA_CHECK_THREAD();
     // Convert to RTT policy.
-    ConnPolicy policy2 = toRTT(corba_policy);
+    ConnPolicy policy = toRTT(corba_policy);
 
     // Now create the output-side channel elements.
     ChannelElementBase::shared_ptr start = type_info->buildChannelInput(*port);
 
     // The channel element that exposes our channel in CORBA
-    CRemoteChannelElement_i* this_element;
-    PortableServer::ServantBase_var servant = this_element = transporter->createChannelElement_i(mdf, mpoa, corba_policy.pull, corba_policy.signalling);
+    CRemoteChannelElement_i* this_element =
+        transporter->createInputChannelElement_i(mpoa, corba_policy.pull);
+    PortableServer::ServantBase_var servant = this_element;
     this_element->setCDataFlowInterface(this);
 
     // Attach the corba channel element first (so OOB is after corba).
@@ -497,15 +508,15 @@ CChannelElement_ptr CDataFlowInterface_i::buildChannelInput(
             log(Error) << "No such transport registered. Check your corba_policy.transport settings or add the transport for type "<< type_info->getTypeName() <<endlog();
             throw CNoCorbaTransport();
         }
-        RTT::base::ChannelElementBase::shared_ptr ceb = type_info->getProtocol(corba_policy.transport)->createStream(port, policy2, true);
+        RTT::base::ChannelElementBase::shared_ptr ceb = type_info->getProtocol(corba_policy.transport)->createStream(port, policy, true);
         // if no user supplied name, pass on the new name.
         if ( strlen( corba_policy.name_id.in()) == 0 )
-            corba_policy.name_id = CORBA::string_dup( policy2.name_id.c_str() );
+            corba_policy.name_id = CORBA::string_dup( policy.name_id.c_str() );
 
         if (ceb) {
             // OOB is added to end of chain.
             start->getOutputEndPoint()->setOutput( ceb );
-            log(Info) <<"Sending data from port "<< policy2.name_id << " to out-of-band protocol "<< corba_policy.transport <<endlog();
+            log(Info) <<"Sending data from port "<< policy.name_id << " to out-of-band protocol "<< corba_policy.transport <<endlog();
         } else {
             log(Error) << "The type transporter for type "<<type_info->getTypeName()<< " failed to create an out-of-band endpoint for port " << port_name<<endlog();
             throw CNoCorbaTransport();
@@ -519,7 +530,7 @@ CChannelElement_ptr CDataFlowInterface_i::buildChannelInput(
 
 
     // Attach to our output port:
-    port->addConnection( new SimpleConnID(), start->getInputEndPoint(), policy2);
+    port->addConnection( new SimpleConnID(), start->getInputEndPoint(), policy);
 
     // DO NOT DO THIS: _remove_ref() is tied to the refcount of the ChannelElementBase !
     //this_element->_remove_ref();

--- a/rtt/transports/corba/DataFlowI.h
+++ b/rtt/transports/corba/DataFlowI.h
@@ -191,6 +191,9 @@ namespace RTT {
             	      ,::RTT::corba::CNoSuchPortException
             	    ));
 
+            static std::string dispatcherNameFromPolicy(
+                    RTT::DataFlowInterface* interface,
+                    RTT::ConnPolicy const& policy);
             CChannelElement_ptr buildChannelOutput(const char* reader_port, RTT::corba::CConnPolicy& policy) ACE_THROW_SPEC ((
             	      CORBA::SystemException
             	      ,::RTT::corba::CNoCorbaTransport

--- a/rtt/transports/corba/RemoteChannelElement.hpp
+++ b/rtt/transports/corba/RemoteChannelElement.hpp
@@ -128,8 +128,9 @@ namespace RTT {
 
             ~RemoteChannelElement()
             {
-                if (mdispatcher)
-                    CorbaDispatcher::Release(mdispatcher);
+                if (mdispatcher) {
+                    CorbaDispatcher::Deref(mdispatcher->getName());
+                }
             }
 
             /** Increase the reference count, called from the CORBA side */

--- a/rtt/transports/corba/RemoteChannelElement.hpp
+++ b/rtt/transports/corba/RemoteChannelElement.hpp
@@ -78,37 +78,58 @@ namespace RTT {
          */
         bool signalling;
 
-	    DataFlowInterface* msender;
+	    DataFlowInterface* msender = nullptr;
+        CorbaDispatcher* mdispatcher = nullptr;
 
         PortableServer::ObjectId_var oid;
 
         std::string localUri;
 	public:
-	    /**
-	     * Create a channel element for remote data exchange.
-	     * @param transport The type specific object that will be used to marshal the data.
-	     * @param poa The POA that manages the underlying CRemoteChannelElement_i.
-	     */
-	    RemoteChannelElement(CorbaTypeTransporter const& transport, DataFlowInterface* sender, PortableServer::POA_ptr poa, bool is_pull, bool is_signalling)
-        : CRemoteChannelElement_i(transport, poa)
-        , valid(true), pull(is_pull), signalling(is_signalling)
-        , msender(sender)
+            /**
+             * Create a channel element for remote data exchange.
+             * @param transport The type specific object that will be used to marshal the data.
+             * @param poa The POA that manages the underlying CRemoteChannelElement_i.
+             */
+            RemoteChannelElement(std::string const& dispatcherName, CorbaTypeTransporter const& transport, PortableServer::POA_ptr poa, bool is_pull, bool is_signalling)
+                    : CRemoteChannelElement_i(transport, poa)
+                    , valid(true), pull(is_pull), signalling(is_signalling)
+                    , mdispatcher(CorbaDispatcher::Acquire(dispatcherName))
             {
                 // Big note about cleanup: The RTT will dispose this object through
-	            // the ChannelElement<T> refcounting. So we only need to inform the
+                // the ChannelElement<T> refcounting. So we only need to inform the
                 // POA that our object is dead in disconnect().
                 // CORBA refcount-managed servants must start with a refcount of
                 // 1
                 this->ref();
                 oid = mpoa->activate_object(this);
-                // Force creation of dispatcher.
-                CorbaDispatcher::Instance(msender);
+
+                localUri = ApplicationServer::orb->object_to_string(_this());
+            }
+            /**
+             * Create a channel element for remote data exchange.
+             * @param transport The type specific object that will be used to marshal the data.
+             * @param poa The POA that manages the underlying CRemoteChannelElement_i.
+             */
+            RemoteChannelElement(CorbaTypeTransporter const& transport, PortableServer::POA_ptr poa, bool is_pull)
+                : CRemoteChannelElement_i(transport, poa)
+                , valid(true), pull(is_pull), signalling(false)
+                , mdispatcher(0)
+            {
+                // Big note about cleanup: The RTT will dispose this object through
+                // the ChannelElement<T> refcounting. So we only need to inform the
+                // POA that our object is dead in disconnect().
+                // CORBA refcount-managed servants must start with a refcount of
+                // 1
+                this->ref();
+                oid = mpoa->activate_object(this);
 
                 localUri = ApplicationServer::orb->object_to_string(_this());
             }
 
             ~RemoteChannelElement()
             {
+                if (mdispatcher)
+                    CorbaDispatcher::Release(mdispatcher);
             }
 
             /** Increase the reference count, called from the CORBA side */
@@ -138,7 +159,7 @@ namespace RTT {
                 // that wrote the data, so we must decouple here to keep hard-RT happy.
                 // the dispatch thread must read the data and send it over by calling transferSample().
                 if (!pull || signalling) {
-                    CorbaDispatcher::Instance(msender)->dispatchChannel( this );
+                    mdispatcher->dispatchChannel( this );
                 }
 
                 return valid;

--- a/rtt/transports/corba/RemotePorts.cpp
+++ b/rtt/transports/corba/RemotePorts.cpp
@@ -142,9 +142,11 @@ RTT::base::ChannelElementBase::shared_ptr RemoteInputPort::buildRemoteChannelOut
 
     // Input side is now ok and waiting for us to complete. We build our corba channel element too
     // and connect it to the remote side and vice versa.
+
+    std::string dispatcherName = CDataFlowInterface_i::dispatcherNameFromPolicy(output_port.getInterface(), policy);
     CRemoteChannelElement_i*  local =
         static_cast<CorbaTypeTransporter*>(type->getProtocol(ORO_CORBA_PROTOCOL_ID))
-                            ->createChannelElement_i(output_port.getInterface(), mpoa, policy.pull, policy.signalling);
+                            ->createOutputChannelElement_i(dispatcherName, mpoa, policy.pull, policy.signalling);
 
     CRemoteChannelElement_var proxy = local->_this();
     local->setRemoteSide(remote);

--- a/rtt/transports/corba/TaskContextServer.cpp
+++ b/rtt/transports/corba/TaskContextServer.cpp
@@ -103,7 +103,7 @@ namespace RTT
                         rootNC->unbind(name);
                         log(Info) << "Successfully removed CTaskContext '"<< mregistered_name <<"' from CORBA Naming Service."<<endlog();
                     }
-                    catch( CosNaming::NamingContext::NotFound ) {
+                    catch( CosNaming::NamingContext::NotFound const& ) {
                         log(Info) << "CTaskContext '"<< mregistered_name << "' task was already unbound."<<endlog();
                     }
                     catch( ... ) {

--- a/tests/corba_test.cpp
+++ b/tests/corba_test.cpp
@@ -871,6 +871,21 @@ BOOST_AUTO_TEST_CASE( testBufferHalfs )
     BOOST_CHECK_EQUAL( result, 4.44);
 }
 
+BOOST_AUTO_TEST_CASE(CorbaDispatcher_instances_are_created_and_refcounted) {
+    std::unique_ptr<RTT::DataFlowInterface> iface(new RTT::DataFlowInterface());
+
+    auto instance = CorbaDispatcher::Acquire("test_dispatcher");
+    BOOST_CHECK_EQUAL("test_dispatcher", instance->getName());
+
+    auto instance2 = CorbaDispatcher::Acquire("test_dispatcher");
+    BOOST_CHECK_EQUAL(instance2, instance);
+
+    CorbaDispatcher::Deref("test_dispatcher");
+    BOOST_CHECK(CorbaDispatcher::hasDispatcher("test_dispatcher"));
+    CorbaDispatcher::Deref("test_dispatcher");
+    BOOST_CHECK(!CorbaDispatcher::hasDispatcher("test_dispatcher"));
+}
+
 BOOST_AUTO_TEST_CASE(multiple_CorbaDispatcher_Instance_calls_are_released_by_a_single_Release) {
     std::unique_ptr<RTT::DataFlowInterface> iface(new RTT::DataFlowInterface());
 

--- a/tests/corba_test.cpp
+++ b/tests/corba_test.cpp
@@ -34,6 +34,7 @@
 #include <transports/corba/CorbaLib.hpp>
 #include <transports/corba/CorbaConnPolicy.hpp>
 #include <transports/corba/RTTCorbaConversion.hpp>
+#include <transports/corba/CorbaDispatcher.hpp>
 
 #include "operations_fixture.hpp"
 
@@ -41,6 +42,7 @@
 
 using namespace std;
 using corba::TaskContextProxy;
+using corba::CorbaDispatcher;
 
 class CorbaTest : public OperationsFixture
 {
@@ -411,7 +413,7 @@ BOOST_AUTO_TEST_CASE( testOperationCallerC_Send )
     BOOST_CHECK_EQUAL( r, 0.0 );
     BOOST_CHECK_EQUAL( cr, -5.0 );
 
-    
+
     mc = tp->provides("methods")->create("m0except", caller->engine());
     BOOST_CHECK_NO_THROW( mc.check() );
     shc = mc.send();
@@ -867,6 +869,32 @@ BOOST_AUTO_TEST_CASE( testBufferHalfs )
     result = 0.0;
     BOOST_CHECK_EQUAL( mi1->read( result ), OldData );
     BOOST_CHECK_EQUAL( result, 4.44);
+}
+
+BOOST_AUTO_TEST_CASE(multiple_CorbaDispatcher_Instance_calls_are_released_by_a_single_Release) {
+    std::unique_ptr<RTT::DataFlowInterface> iface(new RTT::DataFlowInterface());
+
+    auto instance = CorbaDispatcher::Instance(iface.get());
+    auto name = instance->getName();
+    BOOST_CHECK_EQUAL(instance, CorbaDispatcher::Instance(iface.get()));
+    BOOST_CHECK(CorbaDispatcher::hasDispatcher(name));
+    CorbaDispatcher::Release(iface.get());
+    BOOST_CHECK(!CorbaDispatcher::hasDispatcher(name));
+}
+
+BOOST_AUTO_TEST_CASE(multiple_CorbaDispatcher_Instance_calls_are_released_by_a_single_ReleaseAll) {
+    auto iface0 = make_unique<RTT::DataFlowInterface>();
+    auto dispatcher0 = CorbaDispatcher::Instance(iface0.get());
+    CorbaDispatcher::Instance(iface0.get());
+    auto name0 = dispatcher0->getName();
+    auto iface1 = make_unique<RTT::DataFlowInterface>();
+    auto dispatcher1 = CorbaDispatcher::Instance(iface1.get());
+    CorbaDispatcher::Instance(iface1.get());
+    auto name1 = dispatcher1->getName();
+
+    CorbaDispatcher::ReleaseAll();
+    BOOST_CHECK(!CorbaDispatcher::hasDispatcher(name0));
+    BOOST_CHECK(!CorbaDispatcher::hasDispatcher(name1));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test-runner-corba.cpp
+++ b/tests/test-runner-corba.cpp
@@ -102,7 +102,6 @@ public:
             init_unit_test_suite(framework::master_test_suite().argc,framework::master_test_suite().argv);
 	}
 	~InitOrocos(){
-	    corba::CorbaDispatcher::ReleaseAll();
 	    corba::TaskContextServer::ShutdownOrb(true);
 	    corba::TaskContextServer::DestroyOrb();
 


### PR DESCRIPTION
This PR allows to use the `name_id` field of the connection policy to select which dispatcher should be used for this connection, thus allowing to isolate connections (avoiding for instance that a connection to a remote that disappeared to block communication to other hosts)

When doing nothing, a name is generated based on the dataflow object we're connecting with, thus retaining the 1:1 mapping between dispatchers and dataflow interfaces