### PR TITLE
fix: use of exception from stop or cleanup

### DIFF
--- a/rtt/base/TaskCore.cpp
+++ b/rtt/base/TaskCore.cpp
@@ -99,56 +99,74 @@ namespace RTT {
     }
 
     bool TaskCore::configure() {
-        if ( mTaskState == Stopped || mTaskState == PreOperational) {
-            TRY(
-                setTargetState(Stopped);
-                bool successful = configureHook();
-                if (successful) {
-                    if (mTaskState != Stopped && (mTaskState == mTargetState)) {
-                        log(Error) << "in configure(): state has been changed inside the configureHook" << endlog();
-                        log(Error) << "  but configureHook returned true. Bailing out." << endlog();
-                        exception();
-                        return false;
-                    }
-                    else {
-                        setTaskState(Stopped);
-                        return true;
-                    }
-                } else {
-                    setTaskState(PreOperational);
-                    setTargetState(PreOperational);
-                    return false;
-                }
-             ) CATCH(std::exception const& e,
-                log(Error) << "in configure(): switching to exception state because of unhandled exception" << endlog();
-                log(Error) << "  " << e.what() << endlog();
-                exception();
-             ) CATCH_ALL(
-                log(Error) << "in configure(): switching to exception state because of unhandled exception" << endlog();
-                exception();
-             )
+        if ( mTaskState != Stopped && mTaskState != PreOperational) {
+            return false;
         }
-        return false; // no configure when running.
+
+        TRY(
+            return performConfigureTransition();
+        ) CATCH(std::exception const& e,
+            log(Error) << "in configure(): switching to exception state because of unhandled exception" << endlog();
+            log(Error) << "  " << e.what() << endlog();
+            exception();
+        ) CATCH_ALL(
+            log(Error) << "in configure(): switching to exception state because of unhandled exception" << endlog();
+            exception();
+        )
+        return false;
+    }
+
+    bool TaskCore::performConfigureTransition() {
+        setTargetState(Stopped);
+        if (!configureHook()) {
+            if (mTargetState == Stopped) {
+                setTargetState(PreOperational);
+                setTaskState(PreOperational);
+            }
+            return false;
+        }
+
+        if (mTargetState == Stopped) {
+            setTaskState(Stopped);
+            return true;
+        }
+
+        log(Error) << "in configure(): state has been changed inside the configureHook" << endlog();
+        log(Error) << "  but configureHook returned true. Bailing out." << endlog();
+        exception();
+        return false;
     }
 
     bool TaskCore::cleanup() {
-        if ( mTaskState == Stopped ) {
-            TRY(
-                setTargetState(PreOperational);
-                cleanupHook();
-                if (mTaskState == Stopped)
-                    setTaskState(PreOperational);
-                return true;
-             ) CATCH(std::exception const& e,
-                log(Error) << "in cleanup(): switching to exception state because of unhandled exception" << endlog();
-                log(Error) << "  " << e.what() << endlog();
-                exception();
-             ) CATCH_ALL (
-                log(Error) << "in cleanup(): switching to exception state because of unhandled exception" << endlog();
-                exception();
-             )
+        if ( mTaskState != Stopped ) {
+            return false;
         }
+
+        TRY(
+            return performCleanupTransition();
+        ) CATCH(std::exception const& e,
+           log(Error) << "in cleanup(): switching to fatal state because of unhandled exception" << endlog();
+           log(Error) << "  " << e.what() << endlog();
+           fatal();
+        ) CATCH_ALL (
+           log(Error) << "in cleanup(): switching to fatal state because of unhandled exception" << endlog();
+           fatal();
+        )
         return false; // no cleanup when running or not configured.
+    }
+
+    bool TaskCore::performCleanupTransition() {
+        setTargetState(PreOperational);
+        cleanupHook();
+        if (mTargetState == PreOperational) {
+            setTaskState(PreOperational);
+            return true;
+        }
+
+        if (mTargetState == Exception) {
+            performExceptionTransition(PreOperational);
+        }
+        return false;
     }
 
     void TaskCore::fatal() {
@@ -166,25 +184,48 @@ namespace RTT {
     }
 
     void TaskCore::exception() {
-        //log(Error) <<"Exception happend in TaskCore."<<endlog();
-        TaskState copy = mTaskState;
+        if (mTargetState == TaskCore::Exception) {
+            // Already transitioned or transitioning to exception, do nothing
+            return;
+        }
+
+        if (mTargetState != mTaskState) {
+            // Already in transition. Set the target state but we assume the transition
+            // method will actually call the hooks
+            if (inStopTransition() || inCleanupTransition()) {
+                // stop() and cleanup() will take care of doing the exception transition
+                // after the stopHook call
+                setTargetState(Exception);
+                return;
+            }
+        }
+
+        TaskState state = mTaskState;
         setTargetState(Exception);
         TRY (
-            if ( copy >= Running ) {
-                stopHook();
-            }
-            if ( copy >= Stopped && mInitialState == PreOperational ) {
-                cleanupHook();
-            }
-            exceptionHook();
-            setTaskState(Exception);
+            performExceptionTransition(state);
         ) CATCH(std::exception const& e,
-            log(RTT::Error) << "stopHook(), cleanupHook() and/or exceptionHook() raised " << e.what() << ", going into Fatal" << endlog();
+            log(RTT::Error)
+                << "stopHook(), cleanupHook() and/or exceptionHook() raised "
+                << e.what() << ", going into Fatal" << endlog();
             fatal();
         ) CATCH_ALL (
-            log(Error) << "stopHook(), cleanupHook() and/or exceptionHook() raised an exception, going into Fatal" << endlog();
+            log(Error)
+                << "stopHook(), cleanupHook() and/or exceptionHook() raised "
+                << "an exception, going into Fatal" << endlog();
             fatal();
         )
+    }
+
+    void TaskCore::performExceptionTransition(TaskState state) {
+        if (state >= Running) {
+            stopHook();
+        }
+        if (state >= Stopped && mInitialState == PreOperational) {
+            cleanupHook();
+        }
+        exceptionHook();
+        setTaskState(Exception);
     }
 
     bool TaskCore::recover() {
@@ -234,34 +275,63 @@ namespace RTT {
     }
 
     bool TaskCore::stop() {
-        TaskState origTarget = mTaskState;
-        if ( mTaskState >= Running ) {
-            TRY(
-                setTargetState(Stopped);
-                if ( engine()->stopTask(this) ) {
-                    // If updateHook was running, it might have changed the
-                    // state itself (e.g. stopped or exception). Make sure that
-                    // stopping is still relevant
-                    if ( mTaskState >= Running ) {
-                        setTargetState(Stopped);
-                        stopHook();
-                        setTaskState(Stopped);
-                        return true;
-                    }
-                    else {
-                        return false;
-                    }
-                } else if (mTargetState == Stopped) {
-                    setTargetState(origTarget);
-                }
-            ) CATCH(std::exception const& e,
-                log(Error) << "in stop(): switching to exception state because of unhandled exception" << endlog();
-                log(Error) << "  " << e.what() << endlog();
-                exception();
-            ) CATCH_ALL (
-                log(Error) << "in stop(): switching to exception state because of unhandled exception" << endlog();
-                exception();
-            )
+        if ( mTaskState < Running ) {
+            // Not running, invalid transition
+            return false;
+        }
+
+        TRY(
+            if (performStopTransition()) {
+                return true;
+            }
+        ) CATCH(std::exception const& e,
+            log(Error) << "in stop(): switching to fatal state because of unhandled exception" << endlog();
+            log(Error) << "  " << e.what() << endlog();
+            fatal();
+        ) CATCH_ALL (
+            log(Error) << "in stop(): switching to fatal state because of unhandled exception" << endlog();
+            fatal();
+        )
+
+        if (mTargetState != Exception) {
+            return false;
+        }
+
+        TRY(
+            performExceptionTransition(Stopped);
+            return false;
+        ) CATCH(std::exception const& e,
+            log(Error) << "in stop(): switching to fatal state because of unhandled exception during exception transition" << endlog();
+            log(Error) << "  " << e.what() << endlog();
+            fatal();
+        ) CATCH_ALL (
+            log(Error) << "in stop(): switching to fatal state because of unhandled exception during exception transition" << endlog();
+            fatal();
+        )
+
+        return false;
+    }
+
+    bool TaskCore::performStopTransition() {
+        TaskState origState = mTaskState;
+
+        setTargetState(Stopped);
+        if ( !engine()->stopTask(this) ) {
+            setTargetState(origState);
+            return false;
+        }
+
+        // If updateHook was running, it might have changed the
+        // state itself (e.g. stopped or exception). Make sure that
+        // stopping is still relevant
+        if ( mTaskState < Running ) {
+            return true;
+        }
+
+        stopHook();
+        if (mTargetState == Stopped) {
+            setTaskState(Stopped);
+            return true;
         }
         return false;
     }
@@ -284,6 +354,23 @@ namespace RTT {
 
     bool TaskCore::inFatalError() const {
         return mTaskState == FatalError;
+    }
+
+    bool TaskCore::inConfigureTransition() const {
+        return mTaskState == PreOperational && mTargetState == Stopped;
+    }
+
+    bool TaskCore::inStartTransition() const {
+        return mTaskState == Stopped && mTargetState == Running;
+    }
+
+    bool TaskCore::inStopTransition() const {
+        return (mTaskState == Running || mTaskState == RunTimeError) &&
+               mTargetState == Stopped;
+    }
+
+    bool TaskCore::inCleanupTransition() const {
+        return mTaskState == Stopped && mTargetState == PreOperational;
     }
 
     bool TaskCore::inException() const {

--- a/rtt/base/TaskCore.hpp
+++ b/rtt/base/TaskCore.hpp
@@ -206,6 +206,26 @@ namespace RTT
         virtual bool isActive() const;
 
         /**
+         * Inspect if the component is performing the configuration transition.
+         */
+        virtual bool inConfigureTransition() const;
+
+        /**
+         * Inspect if the component is performing the start transition.
+         */
+        virtual bool inStartTransition() const;
+
+        /**
+         * Inspect if the component is performing the start transition.
+         */
+        virtual bool inStopTransition() const;
+
+        /**
+         * Inspect if the component is performing the start transition.
+         */
+        virtual bool inCleanupTransition() const;
+
+        /**
          * Inspect if the component is in the Running or RunTimeError state.
          * As RunTimeError is a substate of Running, this method
          * also returns true when the component is in one of these states.
@@ -498,6 +518,40 @@ namespace RTT
          * Number of cycles that were caused by Trigger triggers.
          */
         unsigned int mTriggerCounter;
+
+        /** Actual implementation of the configure() transition
+         *
+         * Separation is needed to ease debugging. configure() conditionally
+         * handles exceptions, which confuses debugging.
+         *
+         */
+        bool performConfigureTransition();
+
+        /** Actual implementation of the cleanup() transition
+         *
+         * Separation is needed to ease debugging. cleanup() conditionally
+         * handles exceptions, which confuses debugging.
+         *
+         */
+        bool performCleanupTransition();
+
+        /** Actual implementation of the stop() transition
+         *
+         * Separation is needed to ease debugging. exception() conditionally
+         * handles exceptions, which confuses debugging.
+         *
+         */
+        bool performStopTransition();
+
+        /** Actual implementation of the exception() transition
+         *
+         * Separation is needed to ease debugging. exception() conditionally
+         * handles exceptions, which confuses debugging.
+         *
+         * In addition, it allows re-using in stop() and cleanup()
+         *
+         */
+        void performExceptionTransition(TaskState state);
     };
 }}
 

--- a/rtt/base/TaskCore.hpp
+++ b/rtt/base/TaskCore.hpp
@@ -456,12 +456,29 @@ namespace RTT
         virtual void fatal();
 
         /**
-         * Call this method to indicate a
-         * run-time exception happend. First the TaskState is set to Exception.
-         * Next, if the taskstate was >= Running, stopHook() is called.
-         * Next, if the taskstate was >= Stopped, cleanupHook() is called.
-         * Finally, exceptionHook() is called.
-         * If any exception happens in exceptionHook(), fatal() is called.
+         * Call this method to indicate a run-time exception happened.
+         * 
+         * Calling this eventually transitions the task to exception(). When it
+         * happens depends on where the call was made:
+         *
+         * When in configureHook, startHook or updateHook, the call immediately
+         * calls the relevant cleanup hooks, that is:
+         * - configureHook: exceptionHook is called
+         * - startHook: cleanupHook and then exceptionHook are called
+         * - updateHook: stopHook, cleanupHook and then exceptionHook are called
+         *
+         * After the successful execution of these, the task is transitioned to
+         * Exception. If a C++ exception is thrown during this process, the task
+         * immediately transitions to Fatal
+         *
+         * When in stopHook, cleanupHook and exceptionHook will be called once
+         * stopHook returned. The task's state is then Exception. If a C++
+         * exception is thrown during this process, the task immediately
+         * transitions to Fatal
+         *
+         * When in cleanupHook, exceptionHook is called once stopHook returned.
+         * The task's state is then Exception. If a C++ exception is thrown
+         * during this process, the task immediately transitions to Fatal
          */
         virtual void exception();
 

--- a/tests/taskstates_test.cpp
+++ b/tests/taskstates_test.cpp
@@ -832,9 +832,7 @@ BOOST_AUTO_TEST_CASE(test_calling_stop_concurrently_with_updateHook_calling_exce
     task.start();
     BOOST_REQUIRE(!task.inException());
     task.trigger();
-    while(!task.inUpdateHook) {
-        usleep(1000);
-    }
+    while(!task.inUpdateHook) { usleep(1000); }
     BOOST_REQUIRE(!task.inException());
     task.stop();
     BOOST_REQUIRE_EQUAL(1, task.stopHookCalled);
@@ -873,5 +871,228 @@ BOOST_AUTO_TEST_CASE(test_calling_stop_concurrently_with_updateHook_calling_stop
     BOOST_REQUIRE_EQUAL(TaskCore::Stopped, task.getTargetState());
 }
 
-BOOST_AUTO_TEST_SUITE_END()
+/** Base class for the exception transition tests */
+struct exception_hooks_sequence_tests :
+    public RTT::TaskContext
+{
+    int sequence, stopHookSequence, cleanupHookSequence, exceptionHookSequence;
+    exception_hooks_sequence_tests()
+        : RTT::TaskContext("test", RTT::TaskContext::PreOperational)
+        , sequence(0)
+        , stopHookSequence(0)
+        , cleanupHookSequence(0)
+        , exceptionHookSequence(0) {}
 
+    void stopHook() { stopHookSequence = ++sequence; }
+    void cleanupHook() { cleanupHookSequence = ++sequence; }
+    void exceptionHook() { exceptionHookSequence = ++sequence; }
+};
+
+struct call_exception_within_stopHook : exception_hooks_sequence_tests
+{
+    void stopHook()
+    {
+        exception();
+        stopHookSequence = ++sequence;
+    }
+};
+BOOST_AUTO_TEST_CASE(test_calling_exception_within_stopHook_during_a_normal_stop_transition_calls_cleanupHook_and_exceptionHook_after_stopHook_returned) {
+    call_exception_within_stopHook task;
+    task.configure();
+    task.start();
+    task.stop();
+    BOOST_REQUIRE_EQUAL(1, task.stopHookSequence);
+    BOOST_REQUIRE_EQUAL(2, task.cleanupHookSequence);
+    BOOST_REQUIRE_EQUAL(3, task.exceptionHookSequence);
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTaskState());
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTargetState());
+}
+
+struct call_exception_in_updateHook_and_stopHook : exception_hooks_sequence_tests
+{
+    void updateHook()
+    {
+        exception();
+    }
+};
+BOOST_AUTO_TEST_CASE(test_calling_exception_within_stopHook_during_an_exception_transition_initiated_in_RUNNING_calls_cleanupHook_and_exceptionHook_after_stopHook_returned) {
+    call_exception_in_updateHook_and_stopHook task;
+    task.configure();
+    task.start();
+    task.trigger();
+    while(!task.inException()) { usleep(1000); }
+    BOOST_REQUIRE_EQUAL(1, task.stopHookSequence);
+    BOOST_REQUIRE_EQUAL(2, task.cleanupHookSequence);
+    BOOST_REQUIRE_EQUAL(3, task.exceptionHookSequence);
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTaskState());
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTargetState());
+}
+
+struct call_exception_in_cleanupHook : exception_hooks_sequence_tests
+{
+    void cleanupHook()
+    {
+        exception();
+        cleanupHookSequence = ++sequence;
+    }
+};
+BOOST_AUTO_TEST_CASE(test_calling_exception_within_cleanupHook_during_a_normal_cleanup_transition_calls_exceptionHook_after_cleanupHook_returned) {
+    call_exception_in_cleanupHook task;
+    task.configure();
+    task.start();
+    task.stop();
+    BOOST_REQUIRE(!task.cleanup());
+
+    BOOST_REQUIRE_EQUAL(1, task.stopHookSequence);
+    BOOST_REQUIRE_EQUAL(2, task.cleanupHookSequence);
+    BOOST_REQUIRE_EQUAL(3, task.exceptionHookSequence);
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTaskState());
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTargetState());
+}
+struct call_exception_in_updateHook_and_cleanupHook : exception_hooks_sequence_tests
+{
+    void updateHook() { exception(); }
+    void cleanupHook()
+    {
+        exception();
+        cleanupHookSequence = ++sequence;
+    }
+};
+BOOST_AUTO_TEST_CASE(test_calling_exception_within_cleanupHook_during_an_exception_transition_initiated_in_RUNNING_calls_exceptionHook_after_cleanupHook_returned) {
+    call_exception_in_updateHook_and_cleanupHook task;
+    task.configure();
+    task.start();
+    task.trigger();
+    while(!task.inException()) { usleep(1000); }
+
+    BOOST_REQUIRE_EQUAL(1, task.stopHookSequence);
+    BOOST_REQUIRE_EQUAL(2, task.cleanupHookSequence);
+    BOOST_REQUIRE_EQUAL(3, task.exceptionHookSequence);
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTaskState());
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTargetState());
+}
+struct call_exception_in_stopHook_and_cleanupHook : exception_hooks_sequence_tests
+{
+    void stopHook()
+    {
+        exception();
+        stopHookSequence = ++sequence;
+    }
+    void cleanupHook()
+    {
+        exception();
+        cleanupHookSequence = ++sequence;
+    }
+};
+BOOST_AUTO_TEST_CASE(test_calling_exception_within_cleanupHook_during_an_exception_transition_initiated_in_stopHook_calls_exceptionHook_after_cleanupHook_returned) {
+    call_exception_in_stopHook_and_cleanupHook task;
+    task.configure();
+    task.start();
+    task.stop();
+
+    BOOST_REQUIRE_EQUAL(1, task.stopHookSequence);
+    BOOST_REQUIRE_EQUAL(2, task.cleanupHookSequence);
+    BOOST_REQUIRE_EQUAL(3, task.exceptionHookSequence);
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTaskState());
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTargetState());
+}
+
+struct calling_exception_within_exceptionHook_does_nothing :
+    exception_hooks_sequence_tests
+{
+    void updateHook() { exception(); }
+    void exceptionHook()
+    {
+        exception();
+        exceptionHookSequence = ++sequence;
+    }
+};
+
+BOOST_AUTO_TEST_CASE(test_calling_exception_within_exceptionHook_does_nothing) {
+    calling_exception_within_exceptionHook_does_nothing task;
+    task.configure();
+    task.start();
+    task.trigger();
+    while (!task.inException()) { usleep(10000); }
+
+    BOOST_REQUIRE_EQUAL(1, task.stopHookSequence);
+    BOOST_REQUIRE_EQUAL(2, task.cleanupHookSequence);
+    BOOST_REQUIRE_EQUAL(3, task.exceptionHookSequence);
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTaskState());
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTargetState());
+}
+
+struct calling_exception_twice_in_updateHook_calls_transition_hooks_once_only :
+    exception_hooks_sequence_tests
+{
+    void updateHook()
+    {
+        exception();
+        exception();
+    }
+};
+
+BOOST_AUTO_TEST_CASE(test_calling_exception_twice_in_updateHook_calls_transition_hooks_once_only) {
+    calling_exception_twice_in_updateHook_calls_transition_hooks_once_only task;
+    task.configure();
+    task.start();
+    task.trigger();
+    while (!task.inException()) { usleep(10000); }
+
+    BOOST_REQUIRE_EQUAL(1, task.stopHookSequence);
+    BOOST_REQUIRE_EQUAL(2, task.cleanupHookSequence);
+    BOOST_REQUIRE_EQUAL(3, task.exceptionHookSequence);
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTaskState());
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTargetState());
+}
+
+struct calling_exception_twice_in_stopHook_during_a_normal_stop_transition_calls_transition_hooks_once_only :
+    exception_hooks_sequence_tests
+{
+    void stopHook()
+    {
+        stopHookSequence = ++sequence;
+        exception();
+        exception();
+    }
+};
+
+BOOST_AUTO_TEST_CASE(test_calling_exception_twice_in_stopHook_during_a_normal_stop_transition_calls_transition_hooks_once_only) {
+    calling_exception_twice_in_stopHook_during_a_normal_stop_transition_calls_transition_hooks_once_only task;
+    task.configure();
+    task.start();
+    task.stop();
+
+    BOOST_REQUIRE_EQUAL(1, task.stopHookSequence);
+    BOOST_REQUIRE_EQUAL(2, task.cleanupHookSequence);
+    BOOST_REQUIRE_EQUAL(3, task.exceptionHookSequence);
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTaskState());
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTargetState());
+}
+
+struct calling_exception_twice_in_cleanupHook_during_a_normal_cleanup_transition_calls_transition_hooks_once_only :
+    exception_hooks_sequence_tests
+{
+    void cleanupHook()
+    {
+        exception();
+        exception();
+        cleanupHookSequence = ++sequence;
+    }
+};
+
+BOOST_AUTO_TEST_CASE(test_calling_exception_twice_in_cleanupHook_during_a_normal_cleanup_transition_calls_transition_hooks_once_only) {
+    calling_exception_twice_in_cleanupHook_during_a_normal_cleanup_transition_calls_transition_hooks_once_only task;
+    task.configure();
+    task.start();
+    task.stop();
+    task.cleanup();
+
+    BOOST_REQUIRE_EQUAL(1, task.stopHookSequence);
+    BOOST_REQUIRE_EQUAL(2, task.cleanupHookSequence);
+    BOOST_REQUIRE_EQUAL(3, task.exceptionHookSequence);
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTaskState());
+    BOOST_REQUIRE_EQUAL(TaskCore::Exception, task.getTargetState());
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
exception() is actually directly calling stopHook and cleanupHook. Beyond the
fact that it is surprising even to me, it leads to the problem that a piece of
code that calls exception() from within stopHook is essentially an infinite
recursion.

This commit guards against that condition. exception() called within stopHook or cleanupHook does "the right thing", that is finishing the hook and processing the remainder (resp. cleanupHook and exceptionHook and exceptionHook) after it returned. Multiple calls do nothing more.

What I did realize, though, is that we can't transition to exception if stopHook/cleanupHook throw (that's what happens right now). I did change that behaviour to go into Fatal.