### PR TITLE
chore: fix deprecations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ install
 class-dump.txt
 headers.txt
 *.sw?
+
+.cache
+.vscode/c_cpp_properties.json

--- a/rtt/Attribute.hpp
+++ b/rtt/Attribute.hpp
@@ -73,7 +73,7 @@ namespace RTT
          */
         explicit Attribute(const std::string& name)
             : base::AttributeBase(name),
-              data( new internal::ValueDataSource<T>( T() ) )
+              data( new internal::ValueDataSource<T>( T{} ) )
         {}
 
         /**

--- a/rtt/CMakeLists.txt
+++ b/rtt/CMakeLists.txt
@@ -102,6 +102,10 @@ OPTION(PLUGINS_ENABLE_MARSHALLING "Enable reading and writing Orocos Properties 
 ### Scripting
 OPTION(PLUGINS_ENABLE_SCRIPTING "Enable loading Orocos program scripts." ON)
 
+if (NOT PLUGINS_ENABLE_SCRIPTING)
+    set(ORO_DISABLE_SCRIPTING ON)
+endif()
+
 ### RTT-Typekit
 OPTION(PLUGINS_ENABLE_TYPEKIT "Enable default RTT typekit plugin." ON)
 

--- a/rtt/ConfigurationInterface.cpp
+++ b/rtt/ConfigurationInterface.cpp
@@ -40,8 +40,9 @@
 #include "ConfigurationInterface.hpp"
 #include "internal/mystd.hpp"
 #include <functional>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
+using namespace boost::placeholders;
 namespace RTT {
     using namespace detail;
     using namespace std;
@@ -99,6 +100,8 @@ namespace RTT {
 
   bool ConfigurationInterface::removeValue( const std::string& name )
   {
+    using namespace boost::placeholders;
+
     map_t::iterator i = find_if( values.begin(), values.end(), boost::bind(equal_to<std::string>(),name, boost::bind(&AttributeBase::getName, _1)) );
     if ( i != values.end() ) {
         delete (*i);
@@ -110,6 +113,8 @@ namespace RTT {
 
   AttributeBase* ConfigurationInterface::getValue( const std::string& name ) const
   {
+    using namespace boost::placeholders;
+
     map_t::const_iterator i = find_if( values.begin(), values.end(), boost::bind(equal_to<std::string>(),name, boost::bind(&AttributeBase::getName, _1)) );
     if ( i == values.end() ) return 0;
     else return *i;
@@ -117,6 +122,8 @@ namespace RTT {
 
   bool ConfigurationInterface::hasAttribute( const std::string& name ) const
   {
+    using namespace boost::placeholders;
+
     map_t::const_iterator i = find_if( values.begin(), values.end(), boost::bind(equal_to<std::string>(),name, boost::bind(&AttributeBase::getName, _1)) );
     return i != values.end();
   }
@@ -137,6 +144,8 @@ namespace RTT {
 
     std::vector<std::string> ConfigurationInterface::getAttributeNames() const
     {
+        using namespace boost::placeholders;
+
         std::vector<std::string> ret;
         std::transform( values.begin(), values.end(), back_inserter(ret), boost::bind(&AttributeBase::getName, _1) );
         return ret;

--- a/rtt/ExecutionEngine.cpp
+++ b/rtt/ExecutionEngine.cpp
@@ -47,8 +47,10 @@
 #include "internal/CatchConfig.hpp"
 #include "extras/SlaveActivity.hpp"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <algorithm>
+
+using namespace boost::placeholders;
 
 #define ORONUM_EE_MQUEUE_SIZE 100
 

--- a/rtt/InputPort.hpp
+++ b/rtt/InputPort.hpp
@@ -138,11 +138,11 @@ namespace RTT
         { return read(sample, true); }
 
         /** Reads a sample from the connection. \a sample is a reference which
-         * will get updated if a new sample is available. 
-	 * 
+         * will get updated if a new sample is available.
+	 *
 	 * The method returns an enum FlowStatus, which describes what type of
 	 * sample (old or new data) or if a sample was returned (no data)
-         * 
+         *
 	 * With the argument @arg copy_old_data one can specify, if sample should
 	 * be updated in the case that the return type is equal to RTT::OldData.
 	 * In case @arg copy_old_data is false and an old sample is available, the
@@ -150,6 +150,8 @@ namespace RTT
          */
         FlowStatus read(typename base::ChannelElement<T>::reference_t sample, bool copy_old_data)
         {
+            using namespace boost::placeholders;
+
             FlowStatus result = NoData;
             // read and iterate if necessary.
             cmanager.select_reader_channel( boost::bind( &InputPort::do_read, this, boost::ref(sample), boost::ref(result), _1, _2 ), copy_old_data );
@@ -176,7 +178,7 @@ namespace RTT
         /**
          * Get a sample of the data on this port, without actually reading the port's data.
          * It's the complement of OutputPort::setDataSample() and serves to retrieve the size
-         * of a variable sized data type T. Returns default T if !connected() or if the 
+         * of a variable sized data type T. Returns default T if !connected() or if the
          * OutputPort did not use setDataSample(). Returns an example T otherwise.
          * In case multiple inputs are connected to this port a sample from the currently read
          * connection will be returned.

--- a/rtt/OutputPort.hpp
+++ b/rtt/OutputPort.hpp
@@ -229,6 +229,8 @@ namespace RTT
          */
         void setDataSample(const T& sample)
         {
+            using namespace boost::placeholders;
+
             this->sample->Set(sample);
             has_initial_sample = true;
             has_last_written_value = false;
@@ -244,6 +246,8 @@ namespace RTT
          */
         void write(const T& sample)
         {
+            using namespace boost::placeholders;
+
             if (keeps_last_written_value || keeps_next_written_value)
             {
                 keeps_next_written_value = false;

--- a/rtt/Property.hpp
+++ b/rtt/Property.hpp
@@ -375,7 +375,7 @@ namespace RTT
 
         virtual Property<T>* create() const
         {
-            return new Property<T>( _name, _description, T() );
+            return new Property<T>( _name, _description, T{} );
         }
 
         virtual Property<T>* create( const base::DataSourceBase::shared_ptr& datasource ) const

--- a/rtt/PropertyBag.cpp
+++ b/rtt/PropertyBag.cpp
@@ -104,9 +104,7 @@ namespace RTT
 
     bool PropertyBag::addProperty(PropertyBase& p)
     {
-        if (&p == 0)
-            return false;
-        if ( ! p.ready() )
+        if (! p.ready())
             return false;
         mproperties.push_back(&p);
         return true;

--- a/rtt/PropertyBag.cpp
+++ b/rtt/PropertyBag.cpp
@@ -212,7 +212,7 @@ namespace RTT
 
     PropertyBase* PropertyBag::find(const std::string& name) const
     {
-        const_iterator i( std::find_if(mproperties.begin(), mproperties.end(), std::bind2nd(FindProp(), name ) ) );
+        const_iterator i( std::find_if(mproperties.begin(), mproperties.end(), std::bind(FindProp(), placeholders::_1, name ) ) );
         if ( i != mproperties.end() )
             return ( *i );
         return 0;
@@ -220,7 +220,7 @@ namespace RTT
 
     base::PropertyBase* PropertyBag::getProperty(const std::string& name) const
     {
-        const_iterator i( std::find_if(mproperties.begin(), mproperties.end(), std::bind2nd(FindProp(), name ) ) );
+        const_iterator i( std::find_if(mproperties.begin(), mproperties.end(), std::bind(FindProp(), std::placeholders::_1, name ) ) );
         if ( i != mproperties.end() )
             return *i;
         return 0;

--- a/rtt/PropertyBag.cpp
+++ b/rtt/PropertyBag.cpp
@@ -201,7 +201,10 @@ namespace RTT
      *
      * A function object for finding a Property by name.
      */
-    struct FindProp : public std::binary_function<const base::PropertyBase*,const std::string, bool>
+    struct FindProp
+#ifndef ORO_DISABLE_SCRIPTING
+	: public std::binary_function<const base::PropertyBase*,const std::string, bool>
+#endif
     {
         bool operator()(const base::PropertyBase* b1, const std::string& b2) const { return b1->getName() == b2; }
     };

--- a/rtt/PropertyBag.hpp
+++ b/rtt/PropertyBag.hpp
@@ -38,6 +38,7 @@
 #ifndef PI_PROPERTY_BAG
 #define PI_PROPERTY_BAG
 
+#include "rtt-config.h"
 #include "base/PropertyBase.hpp"
 
 #include <vector>
@@ -362,7 +363,10 @@ namespace RTT
          * A function object for finding a Property by name and type.
          */
         template<class T>
-        struct FindPropType : public std::binary_function<const base::PropertyBase*,const std::string, bool>
+        struct FindPropType
+#ifndef ORO_DISABLE_SCRIPTING
+	    : public std::binary_function<const base::PropertyBase*,const std::string, bool>
+#endif
         {
             bool operator()(const base::PropertyBase* b1, const std::string& b2) const { return b1->getName() == b2 && dynamic_cast<const Property<T>* >(b1) != 0; }
         };

--- a/rtt/PropertyBag.hpp
+++ b/rtt/PropertyBag.hpp
@@ -242,7 +242,7 @@ namespace RTT
         template<class T>
         Property<T>* getPropertyType(const std::string& name) const
         {
-            const_iterator i( std::find_if(mproperties.begin(), mproperties.end(), std::bind2nd(FindPropType<T>(), name ) ) );
+            const_iterator i( std::find_if(mproperties.begin(), mproperties.end(), std::bind(FindPropType<T>(), std::placeholders::_1, name ) ) );
             if ( i != mproperties.end() )
                 return dynamic_cast<Property<T>* >(*i);
             return 0;

--- a/rtt/ServiceRequester.cpp
+++ b/rtt/ServiceRequester.cpp
@@ -41,9 +41,11 @@
 #include "internal/mystd.hpp"
 #include "Logger.hpp"
 #include "TaskContext.hpp"
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <utility>
+
+using namespace boost::placeholders;
 
 namespace RTT
 {

--- a/rtt/ServiceRequester.cpp
+++ b/rtt/ServiceRequester.cpp
@@ -99,7 +99,7 @@ namespace RTT
         this->mrowner = new_owner;
     }
 
-    ServiceRequester::shared_ptr ServiceRequester::requires() {
+    ServiceRequester::shared_ptr ServiceRequester::serviceRequest() {
         try {
             return shared_from_this();
         } catch( boost::bad_weak_ptr& /*bw*/ ) {
@@ -110,9 +110,16 @@ namespace RTT
         }
     }
 
-    ServiceRequester::shared_ptr ServiceRequester::requires(const std::string& service_name) {
-        if (service_name == "this")
-            return requires();
+#ifndef ORO_ONLY_CXX20_COMPATIBLE_REQUIRES_INTERFACE
+    ServiceRequester::shared_ptr ServiceRequester::requires() {
+        return serviceRequest();
+    }
+#endif
+
+    ServiceRequester::shared_ptr ServiceRequester::serviceRequest(const std::string& service_name) {
+        if (service_name == "this") {
+            return serviceRequest();
+        }
         shared_ptr sp = mrequests[service_name];
         if (sp)
             return sp;
@@ -120,6 +127,12 @@ namespace RTT
         mrequests[service_name] = sp;
         return sp;
     }
+
+#ifndef ORO_ONLY_CXX20_COMPATIBLE_REQUIRES_INTERFACE
+    ServiceRequester::shared_ptr ServiceRequester::requires(const std::string& service_name) {
+        return serviceRequest(service_name);
+    }
+#endif
 
     bool ServiceRequester::addServiceRequester(ServiceRequester::shared_ptr obj) {
         if ( mrequests.find( obj->getRequestName() ) != mrequests.end() ) {

--- a/rtt/ServiceRequester.hpp
+++ b/rtt/ServiceRequester.hpp
@@ -125,9 +125,12 @@ namespace RTT
 
         base::OperationCallerBaseInvoker* getOperationCaller(const std::string& name);
 
+        ServiceRequester::shared_ptr serviceRequest();
+        ServiceRequester::shared_ptr serviceRequest(const std::string& service_name);
+#ifndef ORO_ONLY_CXX20_COMPATIBLE_REQUIRES_INTERFACE
         ServiceRequester::shared_ptr requires();
-
         ServiceRequester::shared_ptr requires(const std::string& service_name);
+#endif
 
         /**
          * Add a new ServiceRequester to this TaskContext.

--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -44,7 +44,7 @@
 #include <string>
 #include <algorithm>
 #include <functional>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/mem_fn.hpp>
 
 #include "internal/DataSource.hpp"
@@ -59,6 +59,8 @@
 #elif defined(ORO_ACT_DEFAULT_ACTIVITY)
 #include "Activity.hpp"
 #endif
+
+using namespace boost::placeholders;
 
 namespace RTT
 {

--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -191,14 +191,14 @@ namespace RTT
         const std::string& location = this->getName();
         Logger::In in( location.c_str()  );
 
-        vector<string> myreqs = this->requires()->getRequesterNames();
-        vector<string> peerreqs = peer->requires()->getRequesterNames();
+        vector<string> myreqs = this->serviceRequest()->getRequesterNames();
+        vector<string> peerreqs = peer->serviceRequest()->getRequesterNames();
 
-        this->requires()->connectTo( peer->provides() );
+        this->serviceRequest()->connectTo( peer->provides() );
         for (vector<string>::iterator it = myreqs.begin();
              it != myreqs.end();
              ++it) {
-            ServiceRequester::shared_ptr sr = this->requires(*it);
+            ServiceRequester::shared_ptr sr = this->serviceRequest(*it);
             if ( !sr->ready() ) {
                 if (peer->provides()->hasService( *it ))
                     success = sr->connectTo( peer->provides(*it) ) && success;
@@ -208,11 +208,11 @@ namespace RTT
             }
         }
 
-        peer->requires()->connectTo( this->provides() );
+        peer->serviceRequest()->connectTo( this->provides() );
         for (vector<string>::iterator it = peerreqs.begin();
                 it != peerreqs.end();
                 ++it) {
-            ServiceRequester::shared_ptr sr = peer->requires(*it);
+            ServiceRequester::shared_ptr sr = peer->serviceRequest(*it);
             if ( !sr->ready() ) {
                 if (this->provides()->hasService(*it))
                     success = sr->connectTo( this->provides(*it) ) && success;

--- a/rtt/TaskContext.hpp
+++ b/rtt/TaskContext.hpp
@@ -268,15 +268,26 @@ namespace RTT
          * Returns the object that manages which methods this Task
          * requires to be implemented by another task.
          */
+
+        ServiceRequester::shared_ptr serviceRequest() { return tcrequests; }
+
+#ifndef ORO_ONLY_CXX20_COMPATIBLE_REQUIRES_INTERFACE
         ServiceRequester::shared_ptr requires() { return tcrequests; }
+#endif
 
         /**
          * Returns the object that manages which methods this Task
          * requires to be implemented by another service.
          */
-        ServiceRequester::shared_ptr requires(const std::string& service_name) {
-            return tcrequests->requires(service_name);
+        ServiceRequester::shared_ptr serviceRequest(const std::string& service_name) {
+            return tcrequests->serviceRequest(service_name);
         }
+
+#ifndef ORO_ONLY_CXX20_COMPATIBLE_REQUIRES_INTERFACE
+        ServiceRequester::shared_ptr requires(const std::string& service_name) {
+            return serviceRequest(service_name);
+        }
+#endif
 
         /**
          * Connects all requires/provides services of this component to these of a peer.

--- a/rtt/base/BufferLockFree.hpp
+++ b/rtt/base/BufferLockFree.hpp
@@ -81,13 +81,13 @@ namespace RTT
         mutable internal::TsPool<Item> mpool;
         const bool mcircular;
         RTT::os::AtomicInt droppedSamples;
-        
+
     public:
         /**
          * Create a lock-free buffer wich can store \a bufsize elements.
          * @param bufsize the capacity of the buffer.
 '         */
-        BufferLockFree( unsigned int bufsize, const T& initial_value = T(), bool circular = false)
+        BufferLockFree( unsigned int bufsize, const T& initial_value = T{}, bool circular = false)
             : bufs( bufsize ), mpool(bufsize + 1), mcircular(circular), droppedSamples(0)
         {
             mpool.data_sample( initial_value );
@@ -146,7 +146,7 @@ namespace RTT
         {
             return droppedSamples.read();
         }
-        
+
         bool Push( param_t item)
         {
             if ( capacity() == (size_type)bufs.size() ) {
@@ -240,7 +240,7 @@ namespace RTT
             }
             return items.size();
         }
-        
+
         value_t* PopWithoutRelease()
 	{
             Item* ipop;
@@ -249,10 +249,10 @@ namespace RTT
 	    return ipop;
 	}
 
-	void Release(value_t *item) 
+	void Release(value_t *item)
 	{
             if (mpool.deallocate( item ) == false )
-                assert(false);  
+                assert(false);
 	}
     };
 }}

--- a/rtt/deployment/ComponentLoader.cpp
+++ b/rtt/deployment/ComponentLoader.cpp
@@ -408,11 +408,11 @@ bool ComponentLoader::import( std::string const& package, std::string const& pat
     }
 
     // check for absolute path:
-    if ( arg.is_complete() ) {
+    if ( arg.is_absolute() ) {
         // plain import
         bool ret = import(package);
         // if not yet given, test for target subdir:
-        if ( arg.parent_path().leaf() != OROCOS_TARGET_NAME )
+        if ( arg.parent_path().filename() != OROCOS_TARGET_NAME )
             ret = import( (arg / OROCOS_TARGET_NAME).string() ) || ret;
         // if something found, return true:
         if (ret)
@@ -457,7 +457,7 @@ bool ComponentLoader::importInstalledPackage(std::string const& package, std::st
         path_found = true;
         // search in dir + dir/TARGET
         paths += p.string() + default_delimiter + (p / OROCOS_TARGET_NAME).string() + default_delimiter;
-        if ( p.is_complete() ) {
+        if ( p.is_absolute() ) {
             // 2.2.x: path may be absolute or relative to search path.
             //log(Warning) << "You supplied an absolute directory to the import directive. Use 'path' to set absolute directories and 'import' only for packages (sub directories)."<<endlog();
             //log(Warning) << "Please modify your XML file or script. I'm importing it now for the sake of backwards compatibility."<<endlog();
@@ -528,7 +528,7 @@ bool ComponentLoader::loadLibrary( std::string const& name )
 #endif
         return true;
     // bail out if absolute path
-    if ( arg.is_complete() )
+    if ( arg.is_absolute() )
         return false;
 
     // search for relative match

--- a/rtt/internal/BindStorage.hpp
+++ b/rtt/internal/BindStorage.hpp
@@ -41,7 +41,7 @@
 
 #include <boost/function.hpp>
 #include <boost/type_traits/function_traits.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/fusion/include/vector.hpp>
 #include <boost/fusion/include/filter_if.hpp>
 #include "NA.hpp"

--- a/rtt/internal/ConnFactory.hpp
+++ b/rtt/internal/ConnFactory.hpp
@@ -136,7 +136,7 @@ namespace RTT
          * @todo: since setDataSample, initial_value is no longer needed.
          */
         template<typename T>
-        static base::ChannelElementBase* buildDataStorage(ConnPolicy const& policy, const T& initial_value = T())
+        static base::ChannelElementBase* buildDataStorage(ConnPolicy const& policy, const T& initial_value = T{})
         {
             if (policy.type == ConnPolicy::DATA)
             {
@@ -252,7 +252,7 @@ namespace RTT
          * @param initial_value The value to use to initialize the connection's storage buffer.
          */
         template<typename T>
-        static base::ChannelElementBase::shared_ptr buildBufferedChannelOutput(InputPort<T>& port, ConnID* conn_id, ConnPolicy const& policy, T const& initial_value = T() )
+        static base::ChannelElementBase::shared_ptr buildBufferedChannelOutput(InputPort<T>& port, ConnID* conn_id, ConnPolicy const& policy, T const& initial_value = T{} )
         {
             assert(conn_id);
             base::ChannelElementBase::shared_ptr endpoint = new ConnOutputEndpoint<T>(&port, conn_id);

--- a/rtt/internal/ConnectionManager.cpp
+++ b/rtt/internal/ConnectionManager.cpp
@@ -44,12 +44,14 @@
  */
 
 #include "ConnectionManager.hpp"
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/scoped_ptr.hpp>
 #include "../base/PortInterface.hpp"
 #include "../os/MutexLock.hpp"
 #include "../base/InputPortInterface.hpp"
 #include <cassert>
+
+using namespace boost::placeholders;
 
 namespace RTT
 {

--- a/rtt/internal/ConnectionManager.hpp
+++ b/rtt/internal/ConnectionManager.hpp
@@ -54,7 +54,6 @@
 #include "../base/rtt-base-fwd.hpp"
 #include "../base/ChannelElementBase.hpp"
 #include <boost/tuple/tuple.hpp>
-#include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 
 #include <rtt/os/Mutex.hpp>

--- a/rtt/internal/DataSourceStorage.hpp
+++ b/rtt/internal/DataSourceStorage.hpp
@@ -40,7 +40,6 @@
 #define ORO_TASK_DATASOURCE_STORAGE_HPP
 
 #include <boost/function.hpp>
-#include <boost/bind.hpp>
 #include <boost/mem_fn.hpp>
 #include <boost/function_types/function_type.hpp>
 #include <boost/function_types/function_arity.hpp>

--- a/rtt/internal/FusedFunctorDataSource.hpp
+++ b/rtt/internal/FusedFunctorDataSource.hpp
@@ -46,7 +46,7 @@
 #include "../ExecutionEngine.hpp"
 #include "../os/oro_allocator.hpp"
 #include "UnMember.hpp"
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/function.hpp>
 #include <boost/function_types/function_type.hpp>

--- a/rtt/internal/ListLocked.hpp
+++ b/rtt/internal/ListLocked.hpp
@@ -41,7 +41,7 @@
 #define ORO_LIST_LOCKED_HPP
 
 #include <boost/intrusive/list.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/bind/protect.hpp>
 #include <stack>
 #include <vector>

--- a/rtt/internal/OperationCallerBinder.hpp
+++ b/rtt/internal/OperationCallerBinder.hpp
@@ -41,7 +41,7 @@
 
 #include <boost/function.hpp>
 #include <boost/type_traits/function_traits.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/mem_fn.hpp>
 
 namespace RTT
@@ -65,6 +65,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
+		using namespace boost::placeholders;
                 return boost::bind( boost::mem_fn(m), o, _1 );
             }
         };
@@ -74,6 +75,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
+		using namespace boost::placeholders;
                 return boost::bind( boost::mem_fn(m), o, _1, _2 );
             }
         };
@@ -83,6 +85,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
+		using namespace boost::placeholders;
                 return boost::bind( boost::mem_fn(m), o, _1, _2, _3 );
             }
         };
@@ -92,6 +95,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
+		using namespace boost::placeholders;
                 return boost::bind( boost::mem_fn(m), o, _1, _2, _3, _4 );
             }
         };
@@ -101,6 +105,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
+		using namespace boost::placeholders;
                 return boost::bind( boost::mem_fn(m), o, _1, _2, _3, _4, _5 );
             }
         };
@@ -110,6 +115,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
+		using namespace boost::placeholders;
                 return boost::bind( boost::mem_fn(m), o, _1, _2, _3, _4, _5, _6 );
             }
         };
@@ -119,6 +125,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
+		using namespace boost::placeholders;
                 return boost::bind( boost::mem_fn(m), o, _1, _2, _3, _4, _5, _6, _7 );
             }
         };
@@ -128,6 +135,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
+		using namespace boost::placeholders;
                 return boost::bind( boost::mem_fn(m), o, _1, _2, _3, _4, _5, _6, _7, _8 );
             }
         };
@@ -137,6 +145,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
+		using namespace boost::placeholders;
                 return boost::bind( boost::mem_fn(m), o, _1, _2, _3, _4, _5, _6, _7, _8, _9 );
             }
         };

--- a/rtt/internal/OperationInterfacePartFused.hpp
+++ b/rtt/internal/OperationInterfacePartFused.hpp
@@ -206,6 +206,8 @@ namespace RTT
 
 
             virtual Handle produceSignal( base::ActionInterface* func, const std::vector<base::DataSourceBase::shared_ptr>& args, ExecutionEngine* subscriber) const {
+                using namespace boost::placeholders;
+
                 base::OperationCallerInterface::shared_ptr impl = this->op->getOperationCaller();
                 if ( subscriber == impl->getMessageProcessor() )
                     subscriber = 0; // clear out to avoid dispatching
@@ -424,6 +426,8 @@ namespace RTT
                 }
 #ifdef ORO_SIGNALLING_OPERATIONS
                 virtual Handle produceSignal( base::ActionInterface* func, const std::vector<base::DataSourceBase::shared_ptr>& args, ExecutionEngine* subscriber) const {
+                    using namespace boost::placeholders;
+
                     if ( args.size() != arity() ) throw wrong_number_of_args_exception(arity(), args.size() );
                     base::OperationCallerInterface::shared_ptr impl = op->getOperationCaller();
                     if ( subscriber == impl->getMessageProcessor() )

--- a/rtt/internal/SignalBase.cpp
+++ b/rtt/internal/SignalBase.cpp
@@ -37,7 +37,9 @@
 
 
 #include "SignalBase.hpp"
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
+
+using namespace boost::placeholders;
 
 #ifdef ORO_SIGNAL_USE_LIST_LOCK_FREE
 #else

--- a/rtt/internal/TsPool.hpp
+++ b/rtt/internal/TsPool.hpp
@@ -102,7 +102,7 @@ namespace RTT
              * Creates a fixed size memory pool holding \a ssize
              * blocks of memory that can hold an object of class \a T.
              */
-            TsPool(unsigned int ssize, const T& sample = T()) :
+            TsPool(unsigned int ssize, const T& sample = T{}) :
                 pool_size(0), pool_capacity(ssize)
             {
                 pool = new Item[ssize];

--- a/rtt/internal/mystd.hpp
+++ b/rtt/internal/mystd.hpp
@@ -38,6 +38,8 @@
 #ifndef ORO_MYSTD_HPP
 #define ORO_MYSTD_HPP
 
+#include "../rtt-config.h"
+
 #include <boost/type_traits/add_reference.hpp>
 #include <boost/type_traits/add_const.hpp>
 #include <boost/type_traits/is_same.hpp>
@@ -91,7 +93,9 @@ namespace RTT { namespace internal {
 
     template<typename T>
     struct select1st
+#ifndef ORO_DISABLE_SCRIPTING
       : public std::unary_function<T, typename T::first_type>
+#endif
     {
         typename T::first_type operator()( const T& p ) {
             return p.first;
@@ -100,40 +104,14 @@ namespace RTT { namespace internal {
 
     template<typename T>
     struct select2nd
+#ifndef ORO_DISABLE_SCRIPTING
       : public std::unary_function<T, typename T::second_type>
+#endif
     {
         typename T::second_type operator()( const T& p ) {
             return p.second;
         }
     };
-
-#if 0
-    // Alternative implementations, return const ref.
-    template<typename PairT>
-    class select1st
-      : public std::unary_function<PairT, typename PairT::first_type>
-    {
-      typedef typename PairT::first_type ResultT;
-    public:
-      const ResultT& operator()( const PairT& p )
-        {
-          return p.first;
-        };
-    };
-
-    template<typename PairT>
-    class select2nd
-      : public std::unary_function<PairT, typename PairT::second_type>
-    {
-      typedef typename PairT::second_type ResultT;
-    public:
-      const ResultT& operator()( const PairT& p )
-        {
-          return p.second;
-        };
-    };
-#endif
-
 
     // my own handy little extension..
     template<typename MapT>
@@ -166,7 +144,9 @@ namespace std
     // STL specialisations for const references : Add others if necessary.
     template <class _Tp>
     struct equal_to< const _Tp& >
+#ifndef ORO_DISABLE_SCRIPTING
         : public binary_function<const _Tp&, const _Tp& ,bool>
+#endif
     {
         bool operator()(const _Tp& __x, const _Tp& __y) const { return __x == __y; }
     };
@@ -174,7 +154,9 @@ namespace std
     /// One of the @link s20_3_3_comparisons comparison functors@endlink.
     template <class _Tp>
     struct not_equal_to<const _Tp&>
+#ifndef ORO_DISABLE_SCRIPTING
         : public binary_function<const _Tp&, const _Tp&, bool>
+#endif
     {
         bool operator()(const _Tp& __x, const _Tp& __y) const { return __x != __y; }
     };
@@ -182,7 +164,9 @@ namespace std
     /// One of the @link s20_3_3_comparisons comparison functors@endlink.
     template <class _Tp>
     struct greater<const _Tp&>
+#ifndef ORO_DISABLE_SCRIPTING
         : public binary_function<const _Tp&,const _Tp&,bool>
+#endif
     {
         bool operator()(const _Tp& __x, const _Tp& __y) const { return __x > __y; }
     };
@@ -190,7 +174,9 @@ namespace std
     /// One of the @link s20_3_3_comparisons comparison functors@endlink.
     template <class _Tp>
     struct less<const _Tp&>
+#ifndef ORO_DISABLE_SCRIPTING
         : public binary_function<const _Tp&,const _Tp&,bool>
+#endif
     {
         bool operator()(const _Tp& __x, const _Tp& __y) const { return __x < __y; }
     };
@@ -212,7 +198,9 @@ namespace RTT
 
   template<typename T>
   struct identity
+#ifndef ORO_DISABLE_SCRIPTING
     : public std::unary_function<T, T>
+#endif
   {
     const T& operator()( const T& t ) const
       {

--- a/rtt/internal/signal_template.hpp
+++ b/rtt/internal/signal_template.hpp
@@ -43,7 +43,7 @@
 #include "NA.hpp"
 
 #ifdef ORO_SIGNAL_USE_LIST_LOCK_FREE
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #else
 #include "../os/MutexLock.hpp"
 #endif
@@ -134,6 +134,8 @@ namespace RTT {
     public:
 		R emit(OROCOS_SIGNATURE_PARMS)
 		{
+            using namespace boost::placeholders;
+
 #ifdef ORO_SIGNAL_USE_LIST_LOCK_FREE
             this->emitting = true;
 

--- a/rtt/os/StartStopManager.hpp
+++ b/rtt/os/StartStopManager.hpp
@@ -41,7 +41,7 @@
 
 #include "../Time.hpp"
 #include <boost/function.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <vector>
 #include <algorithm>
 #include "../rtt-config.h"

--- a/rtt/os/tlsf/tlsf.c
+++ b/rtt/os/tlsf/tlsf.c
@@ -378,8 +378,8 @@ static __inline__ bhdr_t *FIND_SUITABLE_BLOCK(tlsf_t * _tlsf, int *_fl, int *_sl
 
 static __inline__ void corrupt(const char *msg) {
     static const char *k =  "* Heap corruption detected: *\n";
-    write( STDERR_FILENO, k, strlen(k) );
-    write( STDERR_FILENO, msg, strlen(msg) );
+    (void)write( STDERR_FILENO, k, strlen(k) );
+    (void)write( STDERR_FILENO, msg, strlen(msg) );
     abort();
 }
 

--- a/rtt/plugin/PluginLoader.cpp
+++ b/rtt/plugin/PluginLoader.cpp
@@ -510,7 +510,7 @@ bool PluginLoader::loadLibrary( std::string const& name )
     }
 
     // bail out if absolute path
-    if ( arg.is_complete() )
+    if ( arg.is_absolute() )
         return false;
 
     // try relative match:

--- a/rtt/rtt-config.h.in
+++ b/rtt/rtt-config.h.in
@@ -53,6 +53,7 @@
 
 #cmakedefine ORO_DISABLE_SCRIPTING
 #cmakedefine ORO_DISABLE_PORT_DATA_SCRIPTING
+#cmakedefine ORO_ONLY_CXX20_COMPATIBLE_REQUIRES_INTERFACE
 
 // if not defined, show an error
 #ifndef OROCOS_TARGET

--- a/rtt/rtt-config.h.in
+++ b/rtt/rtt-config.h.in
@@ -51,6 +51,7 @@
 
 #define RTT_HAS_STATE_CHANGE_HOOK
 
+#cmakedefine ORO_DISABLE_SCRIPTING
 #cmakedefine ORO_DISABLE_PORT_DATA_SCRIPTING
 
 // if not defined, show an error

--- a/rtt/scripting/CallFunction.hpp
+++ b/rtt/scripting/CallFunction.hpp
@@ -47,7 +47,7 @@
 #include "../ExecutionEngine.hpp"
 #include "../Logger.hpp"
 #include <boost/shared_ptr.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace RTT
 { namespace scripting {

--- a/rtt/scripting/CommandFunctors.hpp
+++ b/rtt/scripting/CommandFunctors.hpp
@@ -39,7 +39,7 @@
 #ifndef ORO_COMMANDFUNCTORS_HPP
 #define ORO_COMMANDFUNCTORS_HPP
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/type_traits/function_traits.hpp>
 

--- a/rtt/scripting/FunctionGraphBuilder.cpp
+++ b/rtt/scripting/FunctionGraphBuilder.cpp
@@ -304,7 +304,7 @@ namespace RTT {
         //assert( build not used by other than NOP )
         assert( dynamic_cast<CommandNOP*>( this->getCommand(build) ));
         this->setCommand( icom );
-        
+
         GraphVertexCopier gvc( fn->getGraph(), *graph, replacementdss );
         GraphEdgeCopier gec( fn->getGraph(), *graph, replacementdss );
 
@@ -349,12 +349,14 @@ namespace RTT {
 
         Vertex funcStart=*
                          find_if(v1, v2,
-                                 bind2nd( finder<boost::property_map<Graph, vertex_exec_t>::type>() ,
-                                          std::make_pair( vmap, int(VertexNode::func_start_node)) ) );
+                                 bind( finder<boost::property_map<Graph, vertex_exec_t>::type>() ,
+                                      std::placeholders::_1,
+                                       std::make_pair( vmap, int(VertexNode::func_start_node)) ) );
         Vertex funcExit=*
                         find_if(v1, v2,
-                                bind2nd( finder<boost::property_map<Graph, vertex_exec_t>::type>() ,
-                                         std::make_pair( vmap, int(VertexNode::func_exit_node)) ) );
+                                bind( finder<boost::property_map<Graph, vertex_exec_t>::type>() ,
+                                      std::placeholders::_1,
+                                      std::make_pair( vmap, int(VertexNode::func_exit_node)) ) );
 
         // reset their special meanings.
         vmap[funcStart] = VertexNode::normal_node;

--- a/rtt/transports/corba/CorbaDispatcher.cpp
+++ b/rtt/transports/corba/CorbaDispatcher.cpp
@@ -42,6 +42,8 @@
 using namespace RTT;
 using namespace RTT::corba;
 
+using namespace boost::placeholders;
+
 CorbaDispatcher::DispatchMap CorbaDispatcher::DispatchI;
 CorbaDispatcher::InstanceMap CorbaDispatcher::Instances;
 os::Mutex CorbaDispatcher::mlock;

--- a/rtt/transports/corba/ServiceRequesterI.cpp
+++ b/rtt/transports/corba/ServiceRequesterI.cpp
@@ -128,7 +128,7 @@ char * RTT_corba_CServiceRequester_i::getRequestName (
     if ( mrequests.find(svc) == mrequests.end() ) {
         log(Debug) << "Creating CServiceRequester for "<< service_name <<endlog();
         RTT_corba_CServiceRequester_i* mserv;
-        mserv = new RTT_corba_CServiceRequester_i( mservice->requires(service_name), mpoa );
+        mserv = new RTT_corba_CServiceRequester_i( mservice->serviceRequest(service_name), mpoa );
         CServiceRequester_ptr request = mserv->activate_this();
         mrequests[svc] = std::pair<RTT::corba::CServiceRequester_var, PortableServer::ServantBase_var>(request,mserv);
     }

--- a/rtt/transports/corba/TaskContextI.cpp
+++ b/rtt/transports/corba/TaskContextI.cpp
@@ -227,13 +227,13 @@ char * RTT_corba_CTaskContext_i::getDescription (
     const char * service_name)
 {
     std::string svc(service_name);
-    if ( mtask->requires()->requiresService(service_name) == false && svc != "this")
+    if ( mtask->serviceRequest()->requiresService(service_name) == false && svc != "this")
         return CServiceRequester::_nil();
     // Creates service requester for "this"
     if ( CORBA::is_nil( mRequest ) ) {
         log(Debug) << "Creating CServiceRequester for "<< mtask->getName()<<endlog();
         RTT_corba_CServiceRequester_i* mserv;
-        mRequest_i = mserv = new RTT_corba_CServiceRequester_i( mtask->requires(), mpoa );
+        mRequest_i = mserv = new RTT_corba_CServiceRequester_i( mtask->serviceRequest(), mpoa );
         mRequest = mserv->activate_this();
         //CServiceRequester_i::registerServant(mRequest, mtask->requires());
     }

--- a/rtt/transports/corba/TaskContextProxy.cpp
+++ b/rtt/transports/corba/TaskContextProxy.cpp
@@ -198,12 +198,12 @@ namespace RTT
         // Detect already added parts of an interface, does not yet detect removed parts...
         if (CORBA::is_nil(mtask))
             return;
-        
+
         CService_var serv = mtask->getProvider("this");
         this->fetchServices(this->provides(), serv.in() );
 
         CServiceRequester_var srq = mtask->getRequester("this");
-        this->fetchRequesters(this->requires(), srq.in() );
+        this->fetchRequesters(this->serviceRequest(), srq.in() );
         log(Debug) << "All Done."<<endlog();
     }
 
@@ -226,7 +226,7 @@ namespace RTT
                 continue;
             CServiceRequester_var cobj = csrq->getRequest(rqlist[i]);
 
-            ServiceRequester::shared_ptr tobj = this->requires(std::string(rqlist[i]));
+            ServiceRequester::shared_ptr tobj = this->serviceRequest(std::string(rqlist[i]));
 
             // Recurse:
             this->fetchRequesters( tobj, cobj.in() );
@@ -508,7 +508,7 @@ namespace RTT
         return false;
     }
 
-    
+
     bool TaskContextProxy::activate() {
         try {
             if (! CORBA::is_nil(mtask) )
@@ -594,7 +594,7 @@ namespace RTT
         }
         return false;
     }
-    
+
     bool TaskContextProxy::inException() const
     {
         try {

--- a/rtt/typekit/CMakeLists.txt
+++ b/rtt/typekit/CMakeLists.txt
@@ -3,8 +3,36 @@ IF (PLUGINS_ENABLE_TYPEKIT)
     ADD_DEFINITIONS( -DRTT_NO_STD_TYPES )
   endif (NOT PLUGINS_STD_TYPES_SUPPORT)
 
-  FILE( GLOB CPPS [^.]*.cpp )
-  FILE( GLOB HPPS [^.]*.hpp [^.]*.h [^.]*.inl)
+  set(CPPS
+     RealTimeTypekit.cpp
+     RealTimeTypekitStdTypes.cpp
+     RealTimeTypekitTypes.cpp
+  )
+
+
+  set(HPPS
+    BoolTypeInfo.hpp
+    RealTimeTypekit.hpp
+    RTStringTypeInfo.hpp
+    StdStringTypeInfo.hpp
+    StdTypeInfo.hpp
+    Types.hpp
+  )
+
+  if (PLUGINS_ENABLE_SCRIPTING)
+    list(APPEND CPPS
+       RealTimeTypekitConstructors.cpp
+       RealTimeTypekitGlobals.cpp
+       RealTimeTypekitOperators.cpp
+       RealTimeTypekitTypes2.cpp
+    )
+
+    list (APPEND HPPS
+      RTTTypes.hpp
+      ConnPolicyType.hpp
+      StdVectorTypeInfo.hpp
+    )
+  endif()
 
   GLOBAL_ADD_INCLUDE( rtt/typekit ${HPPS})
   GLOBAL_ADD_INCLUDE( rtt/typekit ${CMAKE_CURRENT_BINARY_DIR}/rtt-typekit-config.h)

--- a/rtt/typekit/RealTimeTypekit.cpp
+++ b/rtt/typekit/RealTimeTypekit.cpp
@@ -50,6 +50,12 @@ namespace RTT
         {
             return "rtt-types";
         }
+
+#ifdef ORO_DISABLE_SCRIPTING
+        bool RealTimeTypekitPlugin::loadOperators() { return true; }
+        bool RealTimeTypekitPlugin::loadConstructors() { return true; }
+        bool RealTimeTypekitPlugin::loadGlobals() { return true; }
+#endif
     }
 
 }

--- a/rtt/typekit/RealTimeTypekit.hpp
+++ b/rtt/typekit/RealTimeTypekit.hpp
@@ -56,6 +56,7 @@ namespace RTT
         virtual std::string getName();
 
         virtual bool loadTypes();
+
         virtual bool loadOperators();
         virtual bool loadConstructors();
         virtual bool loadGlobals();

--- a/rtt/typekit/RealTimeTypekitStdTypes.cpp
+++ b/rtt/typekit/RealTimeTypekitStdTypes.cpp
@@ -38,8 +38,8 @@
 
 #include "rtt-typekit-config.h"
 
-#include "RealTimeTypekit.hpp"
 #ifndef RTT_NO_STD_TYPES
+#include "../types/SequenceTypeInfo.hpp"
 #include "StdStringTypeInfo.hpp"
 #endif
 #ifdef OS_RT_MALLOC

--- a/rtt/typekit/RealTimeTypekitTypes.cpp
+++ b/rtt/typekit/RealTimeTypekitTypes.cpp
@@ -50,7 +50,9 @@
 namespace RTT
 {
     namespace types {
+#ifndef ORO_DISABLE_SCRIPTING
         void loadOrocosTypes(TypeInfoRepository::shared_ptr ti);
+#endif
         void loadStdTypes(TypeInfoRepository::shared_ptr ti);
     }
 
@@ -73,7 +75,9 @@ namespace RTT
         ti->addType( new TypeInfoName<void>("void"));
 
         // load the Orocos specific types:
+#ifndef ORO_DISABLE_SCRIPTING
         loadOrocosTypes( ti );
+#endif
         loadStdTypes( ti );
         return true;
     }

--- a/rtt/types/SequenceTypeInfoBase.hpp
+++ b/rtt/types/SequenceTypeInfoBase.hpp
@@ -39,8 +39,12 @@
 #ifndef ORO_SEQUENCE_TYPE_INFO_BASE_HPP
 #define ORO_SEQUENCE_TYPE_INFO_BASE_HPP
 
+#include "../rtt-config.h"
+
+#ifndef ORO_DISABLE_SCRIPTING
 #include "SequenceConstructor.hpp"
 #include "TemplateConstructor.hpp"
+#endif
 #include "PropertyComposition.hpp"
 #include "VectorTemplateComposition.hpp"
 #include "PropertyDecomposition.hpp"
@@ -131,9 +135,11 @@ namespace RTT
             }
 
             bool installTypeInfoObject(TypeInfo* ti) {
+#ifndef ORO_DISABLE_SCRIPTING
                 ti->addConstructor( new SequenceBuilder<T>() );
                 ti->addConstructor( newConstructor( sequence_ctor<T>() ) );
                 ti->addConstructor( newConstructor( sequence_ctor2<T>() ) );
+#endif
                 // Don't delete us, we're memory-managed.
                 return false;
             }


### PR DESCRIPTION
I fixed most warnings related to the increase in C++ version (and boost as well). However, the PR disables the built-in typekit since it relies on type deduction that I did not want to resolve (and Rock should really not depend on that built-in typekit anyways)